### PR TITLE
Wrap lambda block

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,7 @@ BraceWrapping:
     BeforeCatch: true
     BeforeElse: true
     IndentBraces: false
+    BeforeLambdaBody: true
 BreakConstructorInitializersBeforeComma: false
 Cpp11BracedListStyle: true
 ColumnLimit: 140


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #63 

### Change log:
<!-- (Please describe the changes you have made in details. -->
Current clang-format configuration does not wrap lambda block, resulting inconsistency behavior between clang-format and check-style. `BeforeLambdaBody` can wrap lambda block, thus solving the inconsistency. Refer to [BeforeLambdaBody](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) for more information.