### PR TITLE
Disable memory tracker

### DIFF
--- a/base/common/logger_useful.h
+++ b/base/common/logger_useful.h
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 #include <Poco/Logger.h>
 #include <Poco/Message.h>
-#include <Common/CurrentThread.h>
 
 
 namespace
@@ -52,5 +51,4 @@ namespace
 #if defined(ARCADIA_BUILD)
     using Poco::Logger;
     using Poco::Message;
-    using RK::CurrentThread;
 #endif

--- a/base/loggers/ExtendedLogChannel.cpp
+++ b/base/loggers/ExtendedLogChannel.cpp
@@ -1,7 +1,6 @@
 #include "ExtendedLogChannel.h"
 
 #include <sys/time.h>
-#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <common/getThreadId.h>
 
@@ -24,13 +23,6 @@ ExtendedLogMessage ExtendedLogMessage::getFrom(const Poco::Message & base)
     msg_ext.time_seconds = static_cast<UInt32>(tv.tv_sec);
     msg_ext.time_microseconds = static_cast<UInt32>(tv.tv_usec);
     msg_ext.time_in_microseconds = static_cast<UInt64>((tv.tv_sec) * 1000000U + (tv.tv_usec));
-
-    if (current_thread)
-    {
-        auto query_id_ref = CurrentThread::getQueryId();
-        if (query_id_ref.size)
-            msg_ext.query_id.assign(query_id_ref.data, query_id_ref.size);
-    }
 
     msg_ext.thread_id = getThreadId();
 

--- a/base/loggers/ExtendedLogChannel.h
+++ b/base/loggers/ExtendedLogChannel.h
@@ -26,7 +26,6 @@ public:
     uint64_t time_in_microseconds = 0;
 
     uint64_t thread_id = 0;
-    std::string query_id;
 };
 
 

--- a/base/loggers/OwnPatternFormatter.cpp
+++ b/base/loggers/OwnPatternFormatter.cpp
@@ -1,11 +1,12 @@
 #include "OwnPatternFormatter.h"
 
 #include <functional>
+
+#include <Common/CurrentThread.h>
 #include <Common/IO/WriteBufferFromString.h>
 #include <Common/IO/WriteHelpers.h>
-#include <Common/CurrentThread.h>
 #include <common/terminalColors.h>
-#include "Loggers.h"
+#include <loggers/Loggers.h>
 
 
 OwnPatternFormatter::OwnPatternFormatter(const Loggers * loggers_, OwnPatternFormatter::Options options_, bool color_)

--- a/base/loggers/OwnPatternFormatter.cpp
+++ b/base/loggers/OwnPatternFormatter.cpp
@@ -2,7 +2,6 @@
 
 #include <functional>
 
-#include <Common/CurrentThread.h>
 #include <Common/IO/WriteBufferFromString.h>
 #include <Common/IO/WriteHelpers.h>
 #include <common/terminalColors.h>
@@ -51,16 +50,6 @@ void OwnPatternFormatter::formatExtended(const RK::ExtendedLogMessage & msg_ext,
     if (color)
         writeCString(resetColor(), wb);
     writeCString(" ] ", wb);
-
-    /// We write query_id even in case when it is empty (no query context)
-    /// just to be convenient for various log parsers.
-    writeCString("{", wb);
-    if (color)
-        writeString(setColor(std::hash<std::string>()(msg_ext.query_id)), wb);
-    RK::writeString(msg_ext.query_id, wb);
-    if (color)
-        writeCString(resetColor(), wb);
-    writeCString("} ", wb);
 
     writeCString("<", wb);
     int priority = static_cast<int>(msg.getPriority());

--- a/src/Common/ThreadPool.cpp
+++ b/src/Common/ThreadPool.cpp
@@ -1,12 +1,13 @@
-#include <Common/ThreadPool.h>
-#include <Common/Exception.h>
-#include <Common/getNumberOfPhysicalCPUCores.h>
-
-#include <cassert>
 #include <type_traits>
 
 #include <Poco/Util/Application.h>
 #include <Poco/Util/LayeredConfiguration.h>
+
+#include <Common/CurrentMetrics.h>
+#include <Common/Exception.h>
+#include <Common/ThreadPool.h>
+#include <Common/MemoryTracker.h>
+#include <Common/getNumberOfPhysicalCPUCores.h>
 
 namespace RK
 {

--- a/src/Common/ThreadProfileEvents.h
+++ b/src/Common/ThreadProfileEvents.h
@@ -6,6 +6,7 @@
 #include <sys/resource.h>
 #include <pthread.h>
 #include <common/logger_useful.h>
+#include <boost/noncopyable.hpp>
 
 
 #if defined(__linux__)

--- a/src/Common/new_delete.cpp
+++ b/src/Common/new_delete.cpp
@@ -1,7 +1,5 @@
 #include <common/memory.h>
-#include <Common/CurrentMemoryTracker.h>
 
-#include <iostream>
 #include <new>
 
 #if defined(OS_LINUX)
@@ -38,87 +36,27 @@ struct InitializeJemallocZoneAllocatorForOSX
 /// @sa https://en.cppreference.com/w/cpp/memory/new/operator_new
 ///     https://en.cppreference.com/w/cpp/memory/new/operator_delete
 
-namespace Memory
-{
-
-inline ALWAYS_INLINE void trackMemory(std::size_t size)
-{
-    std::size_t actual_size = size;
-
-#if USE_JEMALLOC && JEMALLOC_VERSION_MAJOR >= 5
-    /// The nallocx() function allocates no memory, but it performs the same size computation as the mallocx() function
-    /// @note je_mallocx() != je_malloc(). It's expected they don't differ much in allocation logic.
-    if (likely(size != 0))
-        actual_size = nallocx(size, 0);
-#endif
-
-    CurrentMemoryTracker::alloc(actual_size);
-}
-
-inline ALWAYS_INLINE bool trackMemoryNoExcept(std::size_t size) noexcept
-{
-    try
-    {
-        trackMemory(size);
-    }
-    catch (...)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-inline ALWAYS_INLINE void untrackMemory(void * ptr [[maybe_unused]], std::size_t size [[maybe_unused]] = 0) noexcept
-{
-    try
-    {
-#if USE_JEMALLOC && JEMALLOC_VERSION_MAJOR >= 5
-        /// @note It's also possible to use je_malloc_usable_size() here.
-        if (likely(ptr != nullptr))
-            CurrentMemoryTracker::free(sallocx(ptr, 0));
-#else
-        if (size)
-            CurrentMemoryTracker::free(size);
-#    if defined(_GNU_SOURCE)
-        /// It's innaccurate resource free for sanitizers. malloc_usable_size() result is greater or equal to allocated size.
-        else
-            CurrentMemoryTracker::free(malloc_usable_size(ptr));
-#    endif
-#endif
-    }
-    catch (...)
-    {}
-}
-
-}
 
 /// new
 
 void * operator new(std::size_t size)
 {
-    Memory::trackMemory(size);
     return Memory::newImpl(size);
 }
 
 void * operator new[](std::size_t size)
 {
-    Memory::trackMemory(size);
     return Memory::newImpl(size);
 }
 
 void * operator new(std::size_t size, const std::nothrow_t &) noexcept
 {
-    if (likely(Memory::trackMemoryNoExcept(size)))
-        return Memory::newNoExept(size);
-    return nullptr;
+    return Memory::newNoExept(size);
 }
 
 void * operator new[](std::size_t size, const std::nothrow_t &) noexcept
 {
-    if (likely(Memory::trackMemoryNoExcept(size)))
-        return Memory::newNoExept(size);
-    return nullptr;
+    return Memory::newNoExept(size);
 }
 
 /// delete
@@ -133,24 +71,20 @@ void * operator new[](std::size_t size, const std::nothrow_t &) noexcept
 
 void operator delete(void * ptr) noexcept
 {
-    Memory::untrackMemory(ptr);
     Memory::deleteImpl(ptr);
 }
 
 void operator delete[](void * ptr) noexcept
 {
-    Memory::untrackMemory(ptr);
     Memory::deleteImpl(ptr);
 }
 
 void operator delete(void * ptr, std::size_t size) noexcept
 {
-    Memory::untrackMemory(ptr, size);
     Memory::deleteSized(ptr, size);
 }
 
 void operator delete[](void * ptr, std::size_t size) noexcept
 {
-    Memory::untrackMemory(ptr, size);
     Memory::deleteSized(ptr, size);
 }

--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -16,6 +16,7 @@
 #include <Common/IO/WriteBufferFromString.h>
 #include <Common/ThreadPool.h>
 #include <common/logger_useful.h>
+#include <shared_mutex>
 
 namespace RK
 {

--- a/src/Service/LoggerWrapper.h
+++ b/src/Service/LoggerWrapper.h
@@ -2,6 +2,7 @@
 
 #include <libnuraft/nuraft.hxx> // Y_IGNORE
 #include <common/logger_useful.h>
+#include <common/types.h>
 
 namespace RK
 {

--- a/src/Service/NuRaftLogSegment.h
+++ b/src/Service/NuRaftLogSegment.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <map>
 #include <vector>
+#include <shared_mutex>
 #include <Service/KeeperCommon.h>
 #include <Service/LogEntry.h>
 #include <Service/proto/Log.pb.h>


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #71 

### Change log:
<!-- (Please describe the changes you have made in details. -->
1. Remove thread status from base daemon.
2. Disable memory tracker.
3. Remove query_id form extended log channel.
