### PR TITLE
Set default thread_count to CPU core size.

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -55,8 +55,8 @@
         <!-- Max snapshot interval in second. -->
         <!-- <snapshot_create_interval>3600</snapshot_create_interval> -->
 
-        <!-- Processor thread count, default is 16. -->
-        <!-- <thread_count>16</thread_count> -->
+        <!-- Processor thread count, default is CPU core size. For container is cgroup limit size. -->
+        <!-- <thread_count></thread_count> -->
 
         <!-- 4lwd command white list, default "conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,lgif,rqld,uptm" -->
         <!-- <four_letter_word_white_list></four_letter_word_white_list> -->
@@ -106,8 +106,8 @@
             <!-- NuRaft log level, default is information. -->
             <!-- <raft_logs_level>information</raft_logs_level> -->
 
-            <!-- NuRaft thread pool size, default is 32. -->
-            <!-- <nuraft_thread_size>32</nuraft_thread_size> -->
+            <!-- NuRaft thread pool size, default is CPU core size. For container is cgroup limit size. -->
+            <!-- <nuraft_thread_size></nuraft_thread_size> -->
 
             <!-- Log gap (compared to the leader's latest log) for treating this node as fresh, default is 200. -->
             <!-- <fresh_log_gap>200</fresh_log_gap> -->

--- a/src/Common/getNumberOfPhysicalCPUCores.cpp
+++ b/src/Common/getNumberOfPhysicalCPUCores.cpp
@@ -1,15 +1,206 @@
 #include "getNumberOfPhysicalCPUCores.h"
+#include <filesystem>
+
+#if defined(OS_LINUX)
+#    include <cmath>
+#    include <fstream>
+#endif
+
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include <thread>
+#include <set>
 
+namespace
+{
+
+#if defined(OS_LINUX)
+int32_t readFrom(const std::filesystem::path & filename, int default_value)
+{
+    std::ifstream infile(filename);
+    if (!infile.is_open())
+        return default_value;
+    int idata;
+    if (infile >> idata)
+        return idata;
+    else
+        return default_value;
+}
+
+/// Try to look at cgroups limit if it is available.
+uint32_t getCGroupLimitedCPUCores(unsigned default_cpu_count)
+{
+    uint32_t quota_count = default_cpu_count;
+    std::filesystem::path prefix = "/sys/fs/cgroup";
+    /// cgroupsv2
+    std::ifstream contr_file(prefix / "cgroup.controllers");
+    if (contr_file.is_open())
+    {
+        /// First, we identify the cgroup the process belongs
+        std::ifstream cgroup_name_file("/proc/self/cgroup");
+        if (!cgroup_name_file.is_open())
+            return default_cpu_count;
+
+        // cgroup_name_file always starts with '0::/' for v2
+        cgroup_name_file.ignore(4);
+        std::string cgroup_name;
+        cgroup_name_file >> cgroup_name;
+
+        std::filesystem::path current_cgroup;
+        if (cgroup_name.empty())
+            current_cgroup = prefix;
+        else
+            current_cgroup = prefix / cgroup_name;
+
+        // Looking for cpu.max in directories from the current cgroup to the top level
+        // It does not stop on the first time since the child could have a greater value than parent
+        while (current_cgroup != prefix.parent_path())
+        {
+            std::ifstream cpu_max_file(current_cgroup / "cpu.max");
+            current_cgroup = current_cgroup.parent_path();
+            if (cpu_max_file.is_open())
+            {
+                std::string cpu_limit_str;
+                float cpu_period;
+                cpu_max_file >> cpu_limit_str >> cpu_period;
+                if (cpu_limit_str != "max" && cpu_period != 0)
+                {
+                    float cpu_limit = std::stof(cpu_limit_str);
+                    quota_count = std::min(static_cast<uint32_t>(ceil(cpu_limit / cpu_period)), quota_count);
+                }
+            }
+        }
+        current_cgroup = prefix / cgroup_name;
+        // Looking for cpuset.cpus.effective in directories from the current cgroup to the top level
+        while (current_cgroup != prefix.parent_path())
+        {
+            std::ifstream cpuset_cpus_file(current_cgroup / "cpuset.cpus.effective");
+            current_cgroup = current_cgroup.parent_path();
+            if (cpuset_cpus_file.is_open())
+            {
+                // The line in the file is "0,2-4,6,9-14" cpu numbers
+                // It's always grouped and ordered
+                std::vector<std::string> cpu_ranges;
+                std::string cpuset_line;
+                cpuset_cpus_file >> cpuset_line;
+                if (cpuset_line.empty())
+                    continue;
+                boost::split(cpu_ranges, cpuset_line, boost::is_any_of(","));
+                uint32_t cpus_count = 0;
+                for (const std::string& cpu_number_or_range : cpu_ranges)
+                {
+                    std::vector<std::string> cpu_range;
+                    boost::split(cpu_range, cpu_number_or_range, boost::is_any_of("-"));
+
+                    if (cpu_range.size() == 2)
+                    {
+                        int start = std::stoi(cpu_range[0]);
+                        int end = std::stoi(cpu_range[1]);
+                        cpus_count += (end - start) + 1;
+                    }
+                    else
+                        cpus_count++;
+                }
+                quota_count = std::min(cpus_count, quota_count);
+                break;
+            }
+        }
+        return quota_count;
+    }
+    /// cgroupsv1
+    /// Return the number of milliseconds per period process is guaranteed to run.
+    /// -1 for no quota
+    int cgroup_quota = readFrom(prefix / "cpu/cpu.cfs_quota_us", -1);
+    int cgroup_period = readFrom(prefix / "cpu/cpu.cfs_period_us", -1);
+    if (cgroup_quota > -1 && cgroup_period > 0)
+        quota_count = static_cast<uint32_t>(ceil(static_cast<float>(cgroup_quota) / static_cast<float>(cgroup_period)));
+
+    return std::min(default_cpu_count, quota_count);
+}
+#endif
+
+/// Returns number of physical cores, unlike std::thread::hardware_concurrency() which returns the logical core count. With 2-way SMT
+/// (HyperThreading) enabled, physical_concurrency() returns half of of std::thread::hardware_concurrency(), otherwise return the same.
+#if defined(__x86_64__) && defined(OS_LINUX)
+unsigned physical_concurrency()
+try
+{
+    /// The CPUID instruction isn't reliable across different vendors and CPU models. The best option to get the physical core count is
+    /// to parse /proc/cpuinfo. boost::thread::physical_concurrency() does the same, so use their implementation.
+    ///
+    /// See https://doc.callmematthi.eu/static/webArticles/Understanding%20Linux%20_proc_cpuinfo.pdf
+    std::ifstream proc_cpuinfo("/proc/cpuinfo");
+
+    if (!proc_cpuinfo.is_open())
+        /// In obscure cases (chroot) /proc can be unmounted
+        return std::thread::hardware_concurrency();
+
+    using CoreEntry = std::pair<size_t, size_t>; /// physical id, core id
+    using CoreEntrySet = std::set<CoreEntry>;
+
+    CoreEntrySet core_entries;
+
+    CoreEntry cur_core_entry;
+    std::string line;
+
+    while (std::getline(proc_cpuinfo, line))
+    {
+        size_t pos = line.find(std::string(":"));
+        if (pos == std::string::npos)
+            continue;
+
+        std::string key = line.substr(0, pos);
+        std::string val = line.substr(pos + 1);
+
+        if (key.find("physical id") != std::string::npos)
+        {
+            cur_core_entry.first = std::stoi(val);
+            continue;
+        }
+
+        if (key.find("core id") != std::string::npos)
+        {
+            cur_core_entry.second = std::stoi(val);
+            core_entries.insert(cur_core_entry);
+            continue;
+        }
+    }
+    return core_entries.empty() ? /*unexpected format*/ std::thread::hardware_concurrency() : static_cast<unsigned>(core_entries.size());
+}
+catch (...)
+{
+    return std::thread::hardware_concurrency(); /// parsing error
+}
+#endif
+
+unsigned getNumberOfPhysicalCPUCoresImpl()
+{
+    unsigned cpu_count = std::thread::hardware_concurrency(); /// logical cores (with SMT/HyperThreading)
+
+    /// Most x86_64 CPUs have 2-way SMT (Hyper-Threading).
+    /// Aarch64 and RISC-V don't have SMT so far.
+    /// POWER has SMT and it can be multi-way (e.g. 8-way), but we don't know how ClickHouse really behaves, so use all of them.
+
+#if defined(__x86_64__) && defined(OS_LINUX)
+    /// On really big machines, SMT is detrimental to performance (+ ~5% overhead in ClickBench). On such machines, we limit ourself to the physical cores.
+    /// Few cores indicate it is a small machine, runs in a VM or is a limited cloud instance --> it is reasonable to use all the cores.
+    if (cpu_count >= 32)
+        cpu_count = physical_concurrency();
+#endif
+
+#if defined(OS_LINUX)
+    cpu_count = getCGroupLimitedCPUCores(cpu_count);
+#endif
+
+    return cpu_count;
+}
+
+}
 
 unsigned getNumberOfPhysicalCPUCores()
 {
-    static const unsigned number = []
-    {
-        /// As a fallback (also for non-x86 architectures) assume there are no hyper-threading on the system.
-        /// (Actually, only Aarch64 is supported).
-        return std::thread::hardware_concurrency();
-    }();
-    return number;
+    /// Calculate once.
+    static auto res = getNumberOfPhysicalCPUCoresImpl();
+    return res;
 }

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -1,8 +1,9 @@
 #include <filesystem>
 #include <Service/Settings.h>
 #include <Common/IO/WriteHelpers.h>
+#include <Common/getNumberOfPhysicalCPUCores.h>
 #include <common/logger_useful.h>
-#include "ZooKeeper/ZooKeeperConstants.h"
+#include <ZooKeeper/ZooKeeperConstants.h>
 
 
 namespace RK
@@ -82,7 +83,7 @@ void RaftSettings::loadFromConfig(const String & config_elem, const Poco::Util::
         raft_logs_level = parseNuRaftLogLevel(log_level);
         rotate_log_storage_interval = config.getUInt(get_key("rotate_log_storage_interval"), 100000);
         /// TODO set a value according to CPU size
-        nuraft_thread_size = config.getUInt(get_key("nuraft_thread_size"), 32);
+        nuraft_thread_size = config.getUInt(get_key("nuraft_thread_size"), getNumberOfPhysicalCPUCores());
         fresh_log_gap = config.getUInt(get_key("fresh_log_gap"), 200);
         configuration_change_tries_count = config.getUInt(get_key("configuration_change_tries_count"), 30);
         max_batch_size = config.getUInt(get_key("max_batch_size"), 1000);
@@ -117,7 +118,7 @@ RaftSettingsPtr RaftSettings::getDefault()
 
     settings->raft_logs_level = NuRaftLogLevel::RAFT_LOG_INFORMATION;
     settings->rotate_log_storage_interval = 100000;
-    settings->nuraft_thread_size = 32;
+    settings->nuraft_thread_size = getNumberOfPhysicalCPUCores();
     settings->fresh_log_gap = 200;
     settings->configuration_change_tries_count = 30;
     settings->max_batch_size = 1000;
@@ -237,7 +238,7 @@ SettingsPtr Settings::loadFromConfig(const Poco::Util::AbstractConfiguration & c
     ret->host = config.getString("keeper.host", "0.0.0.0");
 
     ret->internal_port = config.getInt("keeper.internal_port", 8103);
-    ret->thread_count = config.getInt("keeper.thread_count", 16);
+    ret->thread_count = config.getInt("keeper.thread_count", getNumberOfPhysicalCPUCores());
 
     ret->snapshot_create_interval = config.getInt("keeper.snapshot_create_interval", 3600);
     ret->snapshot_create_interval = std::max(ret->snapshot_create_interval, 1);

--- a/tests/integration/test_four_word_command/configs/enable_keeper1.xml
+++ b/tests/integration/test_four_word_command/configs/enable_keeper1.xml
@@ -6,6 +6,7 @@
         <host>node1</host>
         <snapshot_create_interval>10000</snapshot_create_interval>
         <four_letter_word_white_list>*</four_letter_word_white_list>
+        <thread_count>16</thread_count>
 
         <raft_settings>
             <operation_timeout_ms>1000</operation_timeout_ms>
@@ -13,6 +14,7 @@
             <max_session_timeout_ms>30000</max_session_timeout_ms>
             <snapshot_distance>3000000</snapshot_distance>
             <raft_logs_level>debug</raft_logs_level>
+            <nuraft_thread_size>32</nuraft_thread_size>
         </raft_settings>
 
         <cluster>


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #6 

### Change log:
<!-- (Please describe the changes you have made in details. -->
1. `getNumberOfPhysicalCPUCores` should take container into consideration
2. Set default thread_count to CPU core size.
3. Use `getNumberOfPhysicalCPUCores` for IO thread count.
