### PR TITLE
Fix min_latency

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -25,11 +25,6 @@
         <!-- <log_to_console>false</log_to_console> -->
     </logger>
 
-    <!-- <core_dump> -->
-    <!-- 1 GiB by default. If more - it writes to disk too long. -->
-    <!-- <size_limit>1073741824</size_limit> -->
-    <!-- </core_dump> -->
-
     <keeper>
         <!-- My id in cluster. -->
         <my_id>1</my_id>

--- a/src/Service/ConnectionStats.cpp
+++ b/src/Service/ConnectionStats.cpp
@@ -5,7 +5,7 @@ namespace RK
 
 uint64_t ConnectionStats::getMinLatency() const
 {
-    return min_latency;
+    return min_latency == std::numeric_limits<uint64_t>::max() ? static_cast<uint64_t>(0): min_latency;
 }
 
 uint64_t ConnectionStats::getMaxLatency() const
@@ -48,7 +48,7 @@ void ConnectionStats::incrementPacketsSent()
 void ConnectionStats::updateLatency(uint64_t latency_ms)
 {
     last_latency = latency_ms;
-    total_latency += (latency_ms);
+    total_latency += latency_ms;
     count++;
 
     if (latency_ms < min_latency)
@@ -73,8 +73,8 @@ void ConnectionStats::resetLatency()
     total_latency = 0;
     count = 0;
     max_latency = 0;
-    min_latency = 0;
     last_latency = 0;
+    min_latency = std::numeric_limits<uint64_t>::max();
 }
 
 void ConnectionStats::resetRequestCounters()

--- a/tests/integration/test_four_word_command/test.py
+++ b/tests/integration/test_four_word_command/test.py
@@ -454,7 +454,7 @@ def test_cmd_crst(started_cluster):
         assert result['lzxid'] == '0xffffffffffffffff'
         assert result['lresp'] == '0'
         assert int(result['llat']) == 0
-        assert int(result['minlat']) == 18446744073709551615
+        assert int(result['minlat']) == 0
         assert int(result['avglat']) == 0
         assert int(result['maxlat']) == 0
 


### PR DESCRIPTION
### Describe the bug

Illegal `cons` command output: minlat=18446744073709551615
```
recved=0,sent=0,sid=0xffffffffffffffff,lop=NA,est=1691475923259,to=30000,lzxid=0xffffffffffffffff,lresp=0,llat=0,minlat=18446744073709551615,avglat=0,maxlat=0
```

### Change log
1. Fix min latency issue



