### PR TITLE
Fix request processor endless loop

### DIFF
--- a/src/Service/ConnectionHandler.cpp
+++ b/src/Service/ConnectionHandler.cpp
@@ -641,6 +641,7 @@ void ConnectionHandler::sendResponse(const Coordination::ZooKeeperResponsePtr & 
     /// TODO should invoked after response sent to client.
     updateStats(response);
 
+    /// We do not need send anything for close request to client.
     if (response->xid != Coordination::WATCH_XID && response->getOpNum() == Coordination::OpNum::Close)
     {
         responses->push(ptr<FIFOBuffer>());

--- a/src/Service/ForwardRequest.cpp
+++ b/src/Service/ForwardRequest.cpp
@@ -36,7 +36,7 @@ ForwardResponsePtr ForwardHandshakeRequest::makeResponse() const
     return std::make_shared<ForwardHandshakeResponse>();
 }
 
-KeeperStore::RequestForSession ForwardHandshakeRequest::requestForSession() const
+RequestForSession ForwardHandshakeRequest::requestForSession() const
 {
     RequestForSession reuqest_info;
     return reuqest_info;
@@ -62,10 +62,10 @@ ForwardResponsePtr ForwardSessionRequest::makeResponse() const
     return std::make_shared<ForwardSessionResponse>();
 }
 
-KeeperStore::RequestForSession ForwardSessionRequest::requestForSession() const
+RequestForSession ForwardSessionRequest::requestForSession() const
 {
-    RequestForSession reuqest_info;
-    return reuqest_info;
+    RequestForSession request_info;
+    return request_info;
 }
 
 void ForwardGetSessionRequest::readImpl(ReadBuffer & buf)
@@ -100,7 +100,7 @@ ForwardResponsePtr ForwardGetSessionRequest::makeResponse() const
     return res;
 }
 
-KeeperStore::RequestForSession ForwardGetSessionRequest::requestForSession() const
+RequestForSession ForwardGetSessionRequest::requestForSession() const
 {
     RequestForSession reuqest_info;
     reuqest_info.request = request;
@@ -141,7 +141,7 @@ ForwardResponsePtr ForwardUpdateSessionRequest::makeResponse() const
     return res;
 }
 
-KeeperStore::RequestForSession ForwardUpdateSessionRequest::requestForSession() const
+RequestForSession ForwardUpdateSessionRequest::requestForSession() const
 {
     RequestForSession reuqest_info;
     reuqest_info.request = request;
@@ -162,6 +162,10 @@ void ForwardOpRequest::readImpl(ReadBuffer & buf)
     request.request = Coordination::ZooKeeperRequestFactory::instance().get(opnum);
     request.request->xid = xid;
     request.request->readImpl(buf);
+
+//    bool is_internal;
+//    Coordination::read(is_internal, buf);
+//    request.is_internal = is_internal;
 }
 
 void ForwardOpRequest::writeImpl(WriteBuffer & buf) const
@@ -172,6 +176,7 @@ void ForwardOpRequest::writeImpl(WriteBuffer & buf) const
     Coordination::write(request.request->getOpNum(), out_buf);
     request.request->writeImpl(out_buf);
     Coordination::write(out_buf.str(), buf);
+//    Coordination::write(request.is_internal, buf);
 }
 
 
@@ -186,7 +191,7 @@ ForwardResponsePtr ForwardOpRequest::makeResponse() const
     return res;
 }
 
-KeeperStore::RequestForSession ForwardOpRequest::requestForSession() const
+RequestForSession ForwardOpRequest::requestForSession() const
 {
     return request;
 }

--- a/src/Service/ForwardRequest.h
+++ b/src/Service/ForwardRequest.h
@@ -29,7 +29,7 @@ struct ForwardRequest
 
     virtual ForwardResponsePtr makeResponse() const = 0;
 
-    virtual KeeperStore::RequestForSession requestForSession() const = 0;
+    virtual RequestForSession requestForSession() const = 0;
 
     virtual String toString() const = 0;
 
@@ -51,7 +51,7 @@ struct ForwardHandshakeRequest : public ForwardRequest
 
     ForwardResponsePtr makeResponse() const override;
 
-    KeeperStore::RequestForSession requestForSession() const override;
+    RequestForSession requestForSession() const override;
 
     String toString() const override
     {
@@ -78,7 +78,7 @@ struct ForwardSessionRequest : public ForwardRequest
 
     ForwardResponsePtr makeResponse() const override;
 
-    KeeperStore::RequestForSession requestForSession() const override;
+    RequestForSession requestForSession() const override;
 
     String toString() const override
     {
@@ -99,7 +99,7 @@ struct ForwardGetSessionRequest : public ForwardRequest
 
     ForwardResponsePtr makeResponse() const override;
 
-    KeeperStore::RequestForSession requestForSession() const override;
+    RequestForSession requestForSession() const override;
 
     String toString() const override
     {
@@ -120,7 +120,7 @@ struct ForwardUpdateSessionRequest : public ForwardRequest
 
     ForwardResponsePtr makeResponse() const override;
 
-    KeeperStore::RequestForSession requestForSession() const override;
+    RequestForSession requestForSession() const override;
 
     String toString() const override
     {
@@ -132,7 +132,7 @@ struct ForwardUpdateSessionRequest : public ForwardRequest
 
 struct ForwardOpRequest : public ForwardRequest
 {
-    KeeperStore::RequestForSession request;
+    RequestForSession request;
 
     ForwardType forwardType() const override { return ForwardType::Operation; }
 
@@ -142,7 +142,7 @@ struct ForwardOpRequest : public ForwardRequest
 
     ForwardResponsePtr makeResponse() const override;
 
-    KeeperStore::RequestForSession requestForSession() const override;
+    RequestForSession requestForSession() const override;
 
     String toString() const override
     {
@@ -162,7 +162,7 @@ public:
 
     ForwardRequestPtr get(ForwardType op_num) const;
 
-    static ForwardRequestPtr convertFromRequest(const KeeperStore::RequestForSession & request_for_session)
+    static ForwardRequestPtr convertFromRequest(const RequestForSession & request_for_session)
     {
         auto opnum = request_for_session.request->getOpNum();
         switch (opnum)

--- a/src/Service/KeeperCommon.cpp
+++ b/src/Service/KeeperCommon.cpp
@@ -15,9 +15,9 @@ String ErrorRequest::toString() const
         error_code);
 }
 
-String ErrorRequest::getRequestId() const
+RequestId ErrorRequest::getRequestId() const
 {
-    return RequestId{session_id, xid}.toString();
+    return {session_id, xid};
 }
 
 String RequestId::toString() const

--- a/src/Service/KeeperCommon.cpp
+++ b/src/Service/KeeperCommon.cpp
@@ -1,55 +1,69 @@
 #include <Service/KeeperCommon.h>
-#include <Service/WriteBufferFromNuraftBuffer.h>
-#include <ZooKeeper/ZooKeeperCommon.h>
-#include <ZooKeeper/ZooKeeperIO.h>
-#include <boost/algorithm/string/split.hpp>
-#include <Poco/File.h>
-#include <Common/IO/WriteHelpers.h>
-
-using namespace nuraft;
+#include <Service/formatHex.h>
 
 namespace RK
 {
 
-namespace ErrorCodes
+String ErrorRequest::toString() const
 {
-    extern const int INVALID_CONFIG_PARAMETER;
+    return fmt::format(
+        "[session_id:{}, xid:{}, opnum:{}, accepted:{}, error_code:{}]",
+        toHexString(session_id),
+        xid,
+        Coordination::toString(opnum),
+        accepted,
+        error_code);
 }
 
-int Directory::createDir(const std::string & dir)
+String ErrorRequest::getRequestId() const
 {
-    Poco::File(dir).createDirectories();
-    return 0;
+    return RequestId{session_id, xid}.toString();
 }
 
-std::string checkAndGetSuperdigest(const String & user_and_digest)
+String RequestId::toString() const
 {
-    if (user_and_digest.empty())
-        return "";
-
-    std::vector<std::string> scheme_and_id;
-    boost::split(scheme_and_id, user_and_digest, [](char c) { return c == ':'; });
-    if (scheme_and_id.size() != 2 || scheme_and_id[0] != "super")
-        throw Exception(
-            ErrorCodes::INVALID_CONFIG_PARAMETER, "Incorrect superdigest in keeper_server config. Must be 'super:base64string'");
-
-    return user_and_digest;
+    return fmt::format("[session_id:{}, xid:{}]", toHexString(session_id), xid);
 }
 
-nuraft::ptr<nuraft::buffer> getZooKeeperLogEntry(int64_t session_id, int64_t time, const Coordination::ZooKeeperRequestPtr & request)
+bool RequestId::operator==(const RequestId & other) const
 {
-    RK::WriteBufferFromNuraftBuffer buf;
-    RK::writeIntBinary(session_id, buf);
-    request->write(buf);
-    Coordination::write(time, buf);
-    return buf.getBuffer();
+    return session_id == other.session_id && xid == other.xid;
 }
 
-
-ptr<log_entry> makeClone(const ptr<log_entry> & entry)
+std::size_t RequestId::RequestIdHash::operator()(const RequestId & request_id) const
 {
-    ptr<log_entry> clone = cs_new<log_entry>(entry->get_term(), buffer::clone(entry->get_buf()), entry->get_val_type());
-    return clone;
+    std::size_t seed = 0;
+    std::hash<int64_t> hash64;
+    std::hash<int32_t> hash32;
+
+    seed ^= hash64(request_id.session_id);
+    seed ^= hash32(request_id.xid);
+
+    return seed;
+}
+
+String RequestForSession::toString() const
+{
+    return fmt::format(
+        "[session_id: {}, xid:{}, opnum:{}, create_time:{}, server_id:{}, client_id:{}, request:{}]",
+        toHexString(session_id),
+        request->xid,
+        Coordination::toString(request->getOpNum()),
+        create_time,
+        server_id,
+        client_id,
+        request->toString());
+}
+
+String RequestForSession::toSimpleString() const
+{
+    return fmt::format(
+        "[session_id:{}, xid:{}, opnum:{}]", toHexString(session_id), request->xid, Coordination::toString(request->getOpNum()));
+}
+
+RequestId RequestForSession::getRequestId() const
+{
+    return {session_id, request->xid};
 }
 
 }

--- a/src/Service/KeeperCommon.h
+++ b/src/Service/KeeperCommon.h
@@ -1,91 +1,78 @@
 #pragma once
 
-#include <fstream>
-#include <time.h>
-#include <Service/Crc32.h>
-#include <ZooKeeper/IKeeper.h>
 #include <ZooKeeper/ZooKeeperCommon.h>
-#include <libnuraft/log_entry.hxx>
 #include <libnuraft/nuraft.hxx>
-#include <common/logger_useful.h>
 
 
 namespace RK
 {
 
-std::string checkAndGetSuperdigest(const String & user_and_digest);
-nuraft::ptr<nuraft::buffer> getZooKeeperLogEntry(int64_t session_id, int64_t time, const Coordination::ZooKeeperRequestPtr & request);
-nuraft::ptr<nuraft::log_entry> makeClone(const nuraft::ptr<nuraft::log_entry> & entry);
+struct RequestId;
 
-struct BackendTimer
+/// Attached session id to request
+struct RequestForSession
 {
-    static constexpr char TIME_FMT[] = "%Y%m%d%H%M%S";
+    int64_t session_id;
+    Coordination::ZooKeeperRequestPtr request;
 
-    /// default min interval is 1 hour
-    UInt32 interval = 1 * 3600;
-    UInt32 random_window = 1200; //20 minutes
+    /// measured in millisecond
+    int64_t create_time{};
 
-    static void getCurrentTime(std::string & date_str)
+    /// for forward request
+    int32_t server_id{-1};
+    int32_t client_id{-1};
+
+//    /// RaftKeeper can generate request, for example: sessionCleanerTask
+//    bool is_internal{false};
+
+    explicit RequestForSession() = default;
+
+    RequestForSession(Coordination::ZooKeeperRequestPtr request_, int64_t session_id_, int64_t create_time_)
+        : session_id(session_id_), request(request_), create_time(create_time_)
     {
-        time_t curr_time;
-        time(&curr_time);
-        char tmp_buf[24];
-        std::strftime(tmp_buf, sizeof(tmp_buf), TIME_FMT, localtime(&curr_time));
-        date_str = tmp_buf;
     }
 
-    static time_t parseTime(const std::string & date_str)
-    {
-        struct tm prev_tm;
-        memset(&prev_tm, 0, sizeof(tm));
-        strptime(date_str.data(), TIME_FMT, &prev_tm);
-        time_t prev_time = mktime(&prev_tm);
-        return prev_time;
-    }
+    bool isForwardRequest() const { return server_id > -1 && client_id > -1; }
+    RequestId getRequestId() const;
 
-    bool isActionTime(const time_t & prev_time, time_t curr_time) const
-    {
-        if (curr_time == 0L)
-            time(&curr_time);
-        return difftime(curr_time, prev_time) >= (interval + rand() % random_window);
-    }
+    String toString() const;
+    String toSimpleString() const;
+
 };
 
-
-class Directory
+/// Attached session id to response
+struct ResponseForSession
 {
-public:
-    static int createDir(const std::string & path);
+    int64_t session_id;
+    Coordination::ZooKeeperResponsePtr response;
 };
 
-inline int readUInt32(nuraft::ptr<std::fstream> & fs, UInt32 & x)
+/// Simple error request info.
+struct ErrorRequest
 {
-    errno = 0;
-    char * buf = reinterpret_cast<char *>(&x);
-    fs->read(buf, sizeof(UInt32));
-    return fs->good() ? 0 : -1;
-}
+    bool accepted;
+    nuraft::cmd_result_code error_code; /// TODO new error code instead of NuRaft error code
+    int64_t session_id;
+    Coordination::XID xid;
+    Coordination::OpNum opnum;
 
-inline int writeUInt32(nuraft::ptr<std::fstream> & fs, const UInt32 & x)
-{
-    errno = 0;
-    fs->write(reinterpret_cast<const char *>(&x), sizeof(UInt32));
-    return fs->good() ? 0 : -1;
-}
+    String toString() const;
+    String getRequestId() const;
+};
 
-inline int readUInt64(nuraft::ptr<std::fstream> & fs, UInt64 & x)
+/// Global client request id.
+struct RequestId
 {
-    errno = 0;
-    char * buf = reinterpret_cast<char *>(&x);
-    fs->read(buf, sizeof(UInt64));
-    return fs->good() ? 0 : -1;
-}
+    int64_t session_id;
+    Coordination::XID xid;
 
-inline int writeUInt64(nuraft::ptr<std::fstream> & fs, const UInt64 & x)
-{
-    errno = 0;
-    fs->write(reinterpret_cast<const char *>(&x), sizeof(UInt64));
-    return fs->good() ? 0 : -1;
-}
+    String toString() const;
+    bool operator==(const RequestId & other) const;
+
+    struct RequestIdHash
+    {
+        std::size_t operator()(const RequestId & request_id) const;
+    };
+};
 
 }

--- a/src/Service/KeeperCommon.h
+++ b/src/Service/KeeperCommon.h
@@ -47,19 +47,6 @@ struct ResponseForSession
     Coordination::ZooKeeperResponsePtr response;
 };
 
-/// Simple error request info.
-struct ErrorRequest
-{
-    bool accepted;
-    nuraft::cmd_result_code error_code; /// TODO new error code instead of NuRaft error code
-    int64_t session_id;
-    Coordination::XID xid;
-    Coordination::OpNum opnum;
-
-    String toString() const;
-    String getRequestId() const;
-};
-
 /// Global client request id.
 struct RequestId
 {
@@ -74,5 +61,20 @@ struct RequestId
         std::size_t operator()(const RequestId & request_id) const;
     };
 };
+
+/// Simple error request info.
+struct ErrorRequest
+{
+    bool accepted;
+    nuraft::cmd_result_code error_code; /// TODO new error code instead of NuRaft error code
+    int64_t session_id;
+    Coordination::XID xid;
+    Coordination::OpNum opnum;
+
+    String toString() const;
+    RequestId getRequestId() const;
+};
+
+using ErrorRequests = std::list<ErrorRequest>;
 
 }

--- a/src/Service/KeeperDispatcher.cpp
+++ b/src/Service/KeeperDispatcher.cpp
@@ -33,8 +33,6 @@ void KeeperDispatcher::requestThread(RunnerId runner_id)
 {
     setThreadName(("ReqDspchr#" + std::to_string(runner_id)).c_str());
 
-    /// Result of requests batch from previous iteration
-    nuraft::ptr<nuraft::cmd_result<nuraft::ptr<nuraft::buffer>>> prev_result = nullptr;
     /// Requests from previous iteration. We store them to be able
     /// to send errors to the client.
     KeeperStore::RequestsForSessions prev_batch;

--- a/src/Service/KeeperDispatcher.cpp
+++ b/src/Service/KeeperDispatcher.cpp
@@ -41,7 +41,7 @@ void KeeperDispatcher::requestThread(RunnerId runner_id)
 
     while (!shutdown_called)
     {
-        KeeperStore::RequestForSession request_for_session;
+        RequestForSession request_for_session;
 
         UInt64 max_wait = configuration_and_settings->raft_settings->operation_timeout_ms;
 
@@ -54,12 +54,7 @@ void KeeperDispatcher::requestThread(RunnerId runner_id)
             {
                 if (isLocalSession(request_for_session.session_id))
                 {
-                    LOG_TRACE(
-                        log,
-                        "Put request session {}, xid {}, opnum {} to commit processor",
-                        toHexString(request_for_session.session_id),
-                        request_for_session.request->xid,
-                        request_for_session.request->getOpNum());
+                    LOG_TRACE(log, "Put to request processor: {}", request_for_session.toSimpleString());
                     request_processor->push(request_for_session);
                 }
                 /// we should skip close requests from clear session task
@@ -94,7 +89,7 @@ void KeeperDispatcher::responseThread()
 {
     setThreadName("RspDispatcher");
 
-    KeeperStore::ResponseForSession response_for_session;
+    ResponseForSession response_for_session;
     UInt64 max_wait = configuration_and_settings->raft_settings->operation_timeout_ms;
 
     while (!shutdown_called)
@@ -161,7 +156,7 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
             return false;
     }
 
-    KeeperStore::RequestForSession request_info;
+    RequestForSession request_info;
     request_info.request = request;
     request_info.session_id = session_id;
     using namespace std::chrono;
@@ -191,7 +186,7 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
 
 bool KeeperDispatcher::putForwardingRequest(size_t server_id, size_t client_id, ForwardRequestPtr request)
 {
-    KeeperStore::RequestForSession && request_info = request->requestForSession();
+    RequestForSession && request_info = request->requestForSession();
 
     using namespace std::chrono;
     request_info.create_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
@@ -316,7 +311,7 @@ void KeeperDispatcher::shutdown()
         }
 
         LOG_INFO(log, "for unhandled requests sending session expired error to client.");
-        KeeperStore::RequestForSession request_for_session;
+        RequestForSession request_for_session;
         while (requests_queue->tryPopAny(request_for_session))
         {
             auto response = request_for_session.request->makeResponse();
@@ -375,9 +370,10 @@ void KeeperDispatcher::sessionCleanerTask()
                     Coordination::ZooKeeperRequestPtr request
                         = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
-                    KeeperStore::RequestForSession request_info;
+                    RequestForSession request_info;
                     request_info.request = request;
                     request_info.session_id = dead_session;
+//                    request_info.is_internal = true;
                     using namespace std::chrono;
                     request_info.create_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
                     {
@@ -385,7 +381,7 @@ void KeeperDispatcher::sessionCleanerTask()
                         if (!requests_queue->push(std::move(request_info)))
                             throw Exception("Cannot push request to queue", ErrorCodes::SYSTEM_ERROR);
                     }
-                    finishSession(dead_session);
+//                    finishSession(dead_session);
                     LOG_INFO(log, "Dead session close request pushed");
                 }
             }

--- a/src/Service/KeeperServer.cpp
+++ b/src/Service/KeeperServer.cpp
@@ -115,7 +115,7 @@ void KeeperServer::shutdown()
     LOG_INFO(log, "Shut down keeper server done!");
 }
 
-void KeeperServer::putRequest(const KeeperStore::RequestForSession & request_for_session)
+void KeeperServer::putRequest(const RequestForSession & request_for_session)
 {
     auto [session_id, request, time, server, client] = request_for_session;
     if (isLeaderAlive() && request->isReadRequest())
@@ -159,7 +159,7 @@ void KeeperServer::putRequest(const KeeperStore::RequestForSession & request_for
         response->error = result->get_result_code() == nuraft::cmd_result_code::TIMEOUT ? Coordination::Error::ZOPERATIONTIMEOUT
                                                                                         : Coordination::Error::ZCONNECTIONLOSS;
 
-        responses_queue.push(RK::KeeperStore::ResponseForSession{session_id, response});
+        responses_queue.push(RK::ResponseForSession{session_id, response});
         if (!result->get_accepted())
             throw Exception(ErrorCodes::RAFT_ERROR, "Request session {} xid {} error, result is not accepted.", session_id, request->xid);
         else
@@ -173,7 +173,7 @@ void KeeperServer::putRequest(const KeeperStore::RequestForSession & request_for
     }
 }
 
-ptr<nuraft::cmd_result<ptr<buffer>>> KeeperServer::putRequestBatch(const std::vector<KeeperStore::RequestForSession> & request_batch)
+ptr<nuraft::cmd_result<ptr<buffer>>> KeeperServer::putRequestBatch(const std::vector<RequestForSession> & request_batch)
 {
     LOG_DEBUG(log, "process the batch requests {}", request_batch.size());
     std::vector<ptr<buffer>> entries;

--- a/src/Service/KeeperServer.h
+++ b/src/Service/KeeperServer.h
@@ -70,10 +70,10 @@ public:
         std::shared_ptr<RequestProcessor> request_processor_ = nullptr);
 
     /// need replaced with putRequestBatch
-    void putRequest(const KeeperStore::RequestForSession & request);
+    void putRequest(const RequestForSession & request);
 
     /// Put write request into queue and keeper server will append it to NuRaft asynchronously.
-    ptr<nuraft::cmd_result<ptr<buffer>>> putRequestBatch(const std::vector<KeeperStore::RequestForSession> & request_batch);
+    ptr<nuraft::cmd_result<ptr<buffer>>> putRequestBatch(const std::vector<RequestForSession> & request_batch);
 
     /// Allocate a new session id.
     int64_t getSessionID(int64_t session_timeout_ms);

--- a/src/Service/KeeperUtils.cpp
+++ b/src/Service/KeeperUtils.cpp
@@ -1,0 +1,57 @@
+#include <Poco/File.h>
+
+#include <Common/IO/WriteHelpers.h>
+#include <boost/algorithm/string/split.hpp>
+
+#include <Service/KeeperUtils.h>
+#include <Service/WriteBufferFromNuraftBuffer.h>
+#include <ZooKeeper/ZooKeeperCommon.h>
+#include <ZooKeeper/ZooKeeperIO.h>
+
+using namespace nuraft;
+
+namespace RK
+{
+
+namespace ErrorCodes
+{
+    extern const int INVALID_CONFIG_PARAMETER;
+}
+
+int Directory::createDir(const std::string & dir)
+{
+    Poco::File(dir).createDirectories();
+    return 0;
+}
+
+std::string checkAndGetSuperdigest(const String & user_and_digest)
+{
+    if (user_and_digest.empty())
+        return "";
+
+    std::vector<std::string> scheme_and_id;
+    boost::split(scheme_and_id, user_and_digest, [](char c) { return c == ':'; });
+    if (scheme_and_id.size() != 2 || scheme_and_id[0] != "super")
+        throw Exception(
+            ErrorCodes::INVALID_CONFIG_PARAMETER, "Incorrect superdigest in keeper_server config. Must be 'super:base64string'");
+
+    return user_and_digest;
+}
+
+nuraft::ptr<nuraft::buffer> getZooKeeperLogEntry(int64_t session_id, int64_t time, const Coordination::ZooKeeperRequestPtr & request)
+{
+    RK::WriteBufferFromNuraftBuffer buf;
+    RK::writeIntBinary(session_id, buf);
+    request->write(buf);
+    Coordination::write(time, buf);
+    return buf.getBuffer();
+}
+
+
+ptr<log_entry> makeClone(const ptr<log_entry> & entry)
+{
+    ptr<log_entry> clone = cs_new<log_entry>(entry->get_term(), buffer::clone(entry->get_buf()), entry->get_val_type());
+    return clone;
+}
+
+}

--- a/src/Service/KeeperUtils.h
+++ b/src/Service/KeeperUtils.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <fstream>
+#include <time.h>
+#include <Service/Crc32.h>
+#include <ZooKeeper/IKeeper.h>
+#include <ZooKeeper/ZooKeeperCommon.h>
+#include <libnuraft/log_entry.hxx>
+#include <libnuraft/nuraft.hxx>
+#include <common/logger_useful.h>
+
+
+namespace RK
+{
+
+std::string checkAndGetSuperdigest(const String & user_and_digest);
+nuraft::ptr<nuraft::buffer> getZooKeeperLogEntry(int64_t session_id, int64_t time, const Coordination::ZooKeeperRequestPtr & request);
+nuraft::ptr<nuraft::log_entry> makeClone(const nuraft::ptr<nuraft::log_entry> & entry);
+
+struct BackendTimer
+{
+    static constexpr char TIME_FMT[] = "%Y%m%d%H%M%S";
+
+    /// default min interval is 1 hour
+    UInt32 interval = 1 * 3600;
+    UInt32 random_window = 1200; //20 minutes
+
+    static void getCurrentTime(std::string & date_str)
+    {
+        time_t curr_time;
+        time(&curr_time);
+        char tmp_buf[24];
+        std::strftime(tmp_buf, sizeof(tmp_buf), TIME_FMT, localtime(&curr_time));
+        date_str = tmp_buf;
+    }
+
+    static time_t parseTime(const std::string & date_str)
+    {
+        struct tm prev_tm;
+        memset(&prev_tm, 0, sizeof(tm));
+        strptime(date_str.data(), TIME_FMT, &prev_tm);
+        time_t prev_time = mktime(&prev_tm);
+        return prev_time;
+    }
+
+    bool isActionTime(const time_t & prev_time, time_t curr_time) const
+    {
+        if (curr_time == 0L)
+            time(&curr_time);
+        return difftime(curr_time, prev_time) >= (interval + rand() % random_window);
+    }
+};
+
+
+class Directory
+{
+public:
+    static int createDir(const std::string & path);
+};
+
+
+inline int readUInt32(nuraft::ptr<std::fstream> & fs, UInt32 & x)
+{
+    errno = 0;
+    char * buf = reinterpret_cast<char *>(&x);
+    fs->read(buf, sizeof(UInt32));
+    return fs->good() ? 0 : -1;
+}
+
+inline int writeUInt32(nuraft::ptr<std::fstream> & fs, const UInt32 & x)
+{
+    errno = 0;
+    fs->write(reinterpret_cast<const char *>(&x), sizeof(UInt32));
+    return fs->good() ? 0 : -1;
+}
+
+inline int readUInt64(nuraft::ptr<std::fstream> & fs, UInt64 & x)
+{
+    errno = 0;
+    char * buf = reinterpret_cast<char *>(&x);
+    fs->read(buf, sizeof(UInt64));
+    return fs->good() ? 0 : -1;
+}
+
+inline int writeUInt64(nuraft::ptr<std::fstream> & fs, const UInt64 & x)
+{
+    errno = 0;
+    fs->write(reinterpret_cast<const char *>(&x), sizeof(UInt64));
+    return fs->good() ? 0 : -1;
+}
+
+}

--- a/src/Service/NuRaftLogSegment.cpp
+++ b/src/Service/NuRaftLogSegment.cpp
@@ -1,15 +1,18 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <Service/Crc32.h>
-#include <Service/KeeperCommon.h>
-#include <Service/LogEntry.h>
-#include <Service/NuRaftLogSegment.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <unistd.h>
+
 #include <Poco/File.h>
+
 #include <Common/ThreadPool.h>
+
+#include <Service/Crc32.h>
+#include <Service/KeeperUtils.h>
+#include <Service/LogEntry.h>
+#include <Service/NuRaftLogSegment.h>
 
 #ifdef __clang__
 #    pragma clang diagnostic push

--- a/src/Service/NuRaftLogSegment.h
+++ b/src/Service/NuRaftLogSegment.h
@@ -3,14 +3,16 @@
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <vector>
 #include <shared_mutex>
-#include <Service/KeeperCommon.h>
-#include <Service/LogEntry.h>
-#include <Service/proto/Log.pb.h>
+#include <vector>
+
+#include <common/logger_useful.h>
 #include <libnuraft/basic_types.hxx>
 #include <libnuraft/nuraft.hxx>
-#include <common/logger_useful.h>
+
+#include <Service/KeeperUtils.h>
+#include <Service/LogEntry.h>
+#include <Service/proto/Log.pb.h>
 
 
 namespace RK

--- a/src/Service/NuRaftLogSnapshot.cpp
+++ b/src/Service/NuRaftLogSnapshot.cpp
@@ -1,20 +1,23 @@
 #include <algorithm>
-#include <filesystem>
 #include <fcntl.h>
+#include <filesystem>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/uio.h>
 #include <unistd.h>
-#include <Service/KeeperCommon.h>
+
+#include <Poco/File.h>
+#include <Poco/NumberFormatter.h>
+
+#include <Common/Exception.h>
+#include <Common/IO/WriteHelpers.h>
+#include <Common/Stopwatch.h>
+
+#include <Service/KeeperUtils.h>
 #include <Service/NuRaftLogSnapshot.h>
 #include <Service/ReadBufferFromNuraftBuffer.h>
 #include <Service/WriteBufferFromNuraftBuffer.h>
 #include <ZooKeeper/ZooKeeperIO.h>
-#include <sys/uio.h>
-#include <Poco/File.h>
-#include <Poco/NumberFormatter.h>
-#include <Common/Exception.h>
-#include <Common/IO/WriteHelpers.h>
-#include <Common/Stopwatch.h>
 
 #ifdef __clang__
 #    pragma clang diagnostic push

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -2,13 +2,15 @@
 
 #include <map>
 #include <string>
-#include <Service/KeeperCommon.h>
+
+#include <Common/IO/WriteBufferFromFile.h>
+#include <libnuraft/nuraft.hxx>
+
 #include <Service/KeeperStore.h>
+#include <Service/KeeperUtils.h>
 #include <Service/LogEntry.h>
 #include <Service/proto/Log.pb.h>
 #include <ZooKeeper/IKeeper.h>
-#include <libnuraft/nuraft.hxx>
-#include <Common/IO/WriteBufferFromFile.h>
 
 
 namespace RK

--- a/src/Service/NuRaftStateMachine.h
+++ b/src/Service/NuRaftStateMachine.h
@@ -21,7 +21,7 @@ using nuraft::async_result;
 using nuraft::buffer;
 using nuraft::cs_new;
 
-using KeeperResponsesQueue = ThreadSafeQueue<KeeperStore::ResponseForSession>;
+using KeeperResponsesQueue = ThreadSafeQueue<ResponseForSession>;
 
 class RequestProcessor;
 
@@ -225,7 +225,7 @@ public:
     KeeperStore & getStore() { return store; }
 
     /// process read request
-    void processReadRequest(const KeeperStore::RequestForSession & request_for_session);
+    void processReadRequest(const RequestForSession & request_for_session);
 
     /// get expired session
     std::vector<int64_t> getDeadSessions();
@@ -282,12 +282,12 @@ public:
     void shutdown();
 
     /// deserialize a RequestForSession
-    static KeeperStore::RequestForSession parseRequest(nuraft::buffer & data);
+    static RequestForSession parseRequest(nuraft::buffer & data);
     /// serialize a RequestForSession
-    static ptr<buffer> serializeRequest(KeeperStore::RequestForSession & request);
+    static ptr<buffer> serializeRequest(RequestForSession & request);
 
 private:
-    ptr<KeeperStore::RequestForSession> createRequestSession(ptr<log_entry> & entry);
+    ptr<RequestForSession> createRequestSession(ptr<log_entry> & entry);
 
     /// Asynchronously snapshot creating thread.
     /// Now it is not used.

--- a/src/Service/RaftTaskManager.cpp
+++ b/src/Service/RaftTaskManager.cpp
@@ -1,9 +1,11 @@
 #include <fcntl.h>
 #include <stdio.h>
-#include <Service/KeeperCommon.h>
-#include <Service/RaftTaskManager.h>
 #include <sys/uio.h>
+
 #include <Poco/File.h>
+
+#include <Service/KeeperUtils.h>
+#include <Service/RaftTaskManager.h>
 
 namespace RK
 {

--- a/src/Service/RequestAccumulator.cpp
+++ b/src/Service/RequestAccumulator.cpp
@@ -22,7 +22,7 @@ void RequestAccumulator::run(RunnerId runner_id)
 
     while (!shutdown_called)
     {
-        KeeperStore::RequestForSession request_for_session;
+        RequestForSession request_for_session;
 
         bool pop_success;
         if (to_append_batch.empty())
@@ -99,7 +99,7 @@ void RequestAccumulator::shutdown()
 
     shutdown_called = true;
 
-    KeeperStore::RequestForSession request_for_session;
+    RequestForSession request_for_session;
     while (requests_queue->tryPopAny(request_for_session))
     {
         request_processor->onError(

--- a/src/Service/RequestAccumulator.h
+++ b/src/Service/RequestAccumulator.h
@@ -15,7 +15,7 @@ namespace RK
  */
 class RequestAccumulator
 {
-    using RequestForSession = KeeperStore::RequestForSession;
+    using RequestForSession = RequestForSession;
     using NuRaftResult = nuraft::ptr<nuraft::cmd_result<nuraft::ptr<nuraft::buffer>>>;
 
 public:

--- a/src/Service/RequestProcessor.cpp
+++ b/src/Service/RequestProcessor.cpp
@@ -239,7 +239,7 @@ void RequestProcessor::processErrorRequest()
 
     LOG_WARNING(log, "Has {} error requests", errors.size());
 
-    ///TODO error requests are not processed in sequence.
+    ///TODO error requests are not processed in order.
     for (auto it = errors.begin(); it != errors.end();)
     {
         auto [session_id, xid] = it->first;

--- a/src/Service/RequestProcessor.cpp
+++ b/src/Service/RequestProcessor.cpp
@@ -1,4 +1,5 @@
 
+#include <Service/KeeperCommon.h>
 #include <Service/KeeperDispatcher.h>
 #include <ZooKeeper/ZooKeeperCommon.h>
 #include <Common/setThreadName.h>
@@ -16,6 +17,11 @@ void RequestProcessor::push(const RequestForSession & request_for_session)
             cv.notify_all();
         }
     }
+}
+
+void RequestProcessor::systemExist() const
+{
+    ::abort();
 }
 
 void RequestProcessor::run()
@@ -43,12 +49,9 @@ void RequestProcessor::run()
             if (shutdown_called)
                 return;
 
-            /// 1. process error requests
-            processErrorRequest();
-
             size_t committed_request_size = committed_queue.size();
 
-            /// 2. process read request, multi thread
+            /// 1. process read request, multi thread
             for (RunnerId runner_id = 0; runner_id < runner_count; runner_id++)
             {
                 request_thread->trySchedule([this, runner_id] {
@@ -58,8 +61,11 @@ void RequestProcessor::run()
             }
             request_thread->wait();
 
-            /// 3. process committed request, single thread
+            /// 2. process committed request, single thread
             processCommittedRequest(committed_request_size);
+
+            /// 3. process error requests
+            processErrorRequest();
         }
         catch (...)
         {
@@ -71,7 +77,6 @@ void RequestProcessor::run()
 void RequestProcessor::moveRequestToPendingQueue(RunnerId runner_id)
 {
     auto & thread_requests = pending_requests.find(runner_id)->second;
-
     size_t request_size = requests_queue->size(runner_id);
 
     if (request_size)
@@ -92,148 +97,134 @@ void RequestProcessor::moveRequestToPendingQueue(RunnerId runner_id)
     }
 }
 
+bool RequestProcessor::shouldProcessCommittedRequest(const RequestForSession & committed_request, bool & found_in_pending_queue)
+{
+    bool has_read_request = false;
+    bool found_error = false;
+
+    auto runner_id = getRunnerId(committed_request.session_id);
+    auto & my_pending_requests = pending_requests.find(runner_id)->second;
+
+    auto & pending_requests_for_session = my_pending_requests[committed_request.session_id];
+
+    auto process_not_in_pending_queue = [this, &found_in_pending_queue, &committed_request]()
+    {
+        found_in_pending_queue = false;
+        LOG_WARNING(
+            this->log,
+            "Not found committed(write) request {} in pending queue. Possible reason: 1.close requests from sessionCleanerTask are not put "
+            "into pending queue; 2.error occurs(because of forward or append entries) but request is still committed, "
+            "'processErrorRequest' may delete request from pending request first, so here we can not find it.",
+            committed_request.toSimpleString());
+    };
+
+    if (pending_requests_for_session.empty())
+    {
+        process_not_in_pending_queue();
+        return true;
+    }
+
+    auto & first_pending_request = pending_requests_for_session.front();
+    LOG_DEBUG(log, "First session pending request {}", first_pending_request.toSimpleString());
+
+    if (first_pending_request.request->xid == committed_request.request->xid)
+    {
+        found_in_pending_queue = true;
+        std::unique_lock lk(mutex);
+        if (errors.contains(first_pending_request.getRequestId()))
+        {
+            LOG_WARNING(log, "Request {} is in errors, but is successfully committed", committed_request.toSimpleString());
+        }
+        return true;
+    }
+    else
+    {
+        found_in_pending_queue = false;
+        /// Session of the previous committed(write) request is not same with the current,
+        /// which means a write_request(session_1) -> request(session_2) sequence.
+        if (first_pending_request.request->isReadRequest())
+        {
+            LOG_DEBUG(log, "Found read request, We should terminate the processing of committed(write) requests.");
+            has_read_request = true;
+        }
+        else
+        {
+            {
+                std::unique_lock lk(mutex);
+                found_error = errors.contains(first_pending_request.getRequestId());
+            }
+
+            if (found_error)
+                LOG_WARNING(log, "Found error request, We should terminate the processing of committed(write) requests.");
+            else
+                process_not_in_pending_queue();
+        }
+    }
+
+    return !has_read_request && !found_error;
+}
 
 void RequestProcessor::processCommittedRequest(size_t count)
 {
-    LOG_DEBUG(log, "Process committed request size {}", count);
     RequestForSession committed_request;
     for (size_t i = 0; i < count; ++i)
     {
-        if (committed_queue.peek(committed_request))
+        if (!committed_queue.peek(committed_request))
+            continue;
+
+        LOG_DEBUG(log, "Process committed(write) request {}", committed_request.toString());
+
+        auto runner_id = getRunnerId(committed_request.session_id);
+        auto & my_pending_requests = pending_requests.find(runner_id)->second;
+
+        /// Remote requests
+        if (!keeper_dispatcher->isLocalSession(committed_request.session_id))
         {
-            auto & pending_requests_for_thread = pending_requests.find(getRunnerId(committed_request.session_id))->second;
-
-            LOG_DEBUG(
-                log,
-                "Committed request session {} xid {} request {}, session {} pending requests size {},",
-                toHexString(committed_request.session_id),
-                committed_request.request->xid,
-                committed_request.request->toString(),
-                toHexString(committed_request.session_id),
-                pending_requests_for_thread.contains(committed_request.session_id)
-                    ? pending_requests_for_thread[committed_request.session_id].size()
-                    : 0
-                );
-
-            auto op_num = committed_request.request->getOpNum();
-
-            /// Remote requests
-            if (!keeper_dispatcher->isLocalSession(committed_request.session_id)
-                || op_num == Coordination::OpNum::Auth)
+            if (my_pending_requests.contains(committed_request.session_id))
             {
-                LOG_DEBUG(log, "Not contains session {}", committed_request.session_id);
-                if (pending_requests_for_thread.contains(committed_request.session_id))
-                {
-                    LOG_WARNING(
-                        log,
-                        "Found session {} in pending_queue while it is not local, maybe because of connection disconnected. "
-                        "Just delete from pending queue",
-                        toHexString(committed_request.session_id));
-                    pending_requests_for_thread.erase(committed_request.session_id);
-                }
+                LOG_WARNING(
+                    log,
+                    "Found session {} in pending_queue while it is not local, maybe because of connection disconnected. "
+                    "Just delete from pending queue",
+                    toHexString(committed_request.session_id));
+                my_pending_requests.erase(committed_request.session_id);
+            }
+
+            LOG_WARNING(
+                log,
+                "Session {} is not local, maybe it is because of disconnecting. We still should apply the committed(write) "
+                "request",
+                committed_request.session_id);
+
+            applyRequest(committed_request);
+            committed_queue.pop();
+        }
+        /// Local requests
+        else
+        {
+            if (committed_request.request->getOpNum() == Coordination::OpNum::Auth)
+            {
+                LOG_DEBUG(log, "Apply auth request", committed_request.session_id);
                 applyRequest(committed_request);
                 committed_queue.pop();
             }
-            /// Local requests
             else
             {
-                bool has_read_request = false;
-                bool found_error = false;
-                auto & pending_requests_for_session = pending_requests_for_thread[committed_request.session_id];
-                if (!pending_requests_for_session.empty())
-                {
-                    LOG_DEBUG(
-                        log,
-                        "Current session pending request opNum {}, session {}, xid {}",
-                        Coordination::toString(pending_requests_for_session.begin()->request->getOpNum()),
-                        toHexString(pending_requests_for_session.begin()->session_id),
-                        pending_requests_for_session.begin()->request->xid);
-
-                    while (pending_requests_for_session.begin()->request->xid != committed_request.request->xid)
-                    {
-                        auto current_begin_request_session = pending_requests_for_session.begin();
-                        if (current_begin_request_session->request->isReadRequest())
-                        {
-                            LOG_DEBUG(
-                                log,
-                                "Current session {} pending head request xid {} {} is read request",
-                                toHexString(committed_request.session_id),
-                                current_begin_request_session->session_id,
-                                current_begin_request_session->request->xid);
-
-                            has_read_request = true;
-                            break;
-                        }
-                        /// Because close's xid is not necessarily CLOSE_XID.
-                        else if (
-                            current_begin_request_session->request->getOpNum() == Coordination::OpNum::Close
-                            && committed_request.request->getOpNum() == Coordination::OpNum::Close)
-                        {
-                            break;
-                        }
-                        else
-                        {
-                            std::unique_lock lk(mutex);
-                            if (errors.contains(UInt128(
-                                    current_begin_request_session->session_id, current_begin_request_session->request->xid)))
-                            {
-                                LOG_WARNING(
-                                    log,
-                                    "Current session {} pending head request xid {} not same committed request xid {} opnum "
-                                    "{}, "
-                                    "because it is in errors",
-                                    toHexString(committed_request.session_id),
-                                    current_begin_request_session->request->xid,
-                                    committed_request.request->xid,
-                                    Coordination::toString(committed_request.request->getOpNum()));
-
-                                found_error = true;
-                                break;
-                            }
-                            else
-                            {
-                                /// TODO should exit？
-                                LOG_WARNING(
-                                    log,
-                                    "Logic Error, maybe reconnected current session {} pending head request xid {} {} not same "
-                                    "committed request xid {} {}, pending request size {}",
-                                    toHexString(committed_request.session_id),
-                                    current_begin_request_session->request->xid,
-                                    current_begin_request_session->request->toString(),
-                                    committed_request.request->xid,
-                                    committed_request.request->toString(),
-                                    pending_requests_for_session.size());
-                                break;
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    LOG_WARNING(log, "Logic error, pending request is empty for session {}", toHexString(committed_request.session_id));
-                }
-
-                if (has_read_request || found_error)
+                bool found_in_pending_queue;
+                if (!shouldProcessCommittedRequest(committed_request, found_in_pending_queue))
                     break;
 
+                /// apply request
                 applyRequest(committed_request);
                 committed_queue.pop();
 
-                for (auto it = pending_requests_for_session.begin(); it != pending_requests_for_session.end();)
-                {
-                    auto xid = it->request->xid;
-                    auto opnum = it->request->getOpNum();
-                    it = pending_requests_for_session.erase(it);
-                    if (xid == committed_request.request->xid
-                        || (opnum == Coordination::OpNum::Close
-                            && committed_request.request->getOpNum() == Coordination::OpNum::Close))
-                    {
-                        break;
-                    }
-                }
+                /// remove request from pending queue
+                auto & pending_requests_for_session = my_pending_requests[committed_request.session_id];
+                if (found_in_pending_queue)
+                    pending_requests_for_session.erase(pending_requests_for_session.begin());
 
                 if (pending_requests_for_session.empty())
-                    pending_requests_for_thread.erase(committed_request.session_id);
+                    my_pending_requests.erase(committed_request.session_id);
             }
         }
     }
@@ -241,131 +232,119 @@ void RequestProcessor::processCommittedRequest(size_t count)
 
 void RequestProcessor::processErrorRequest()
 {
-    /// 1. handle error requests
     std::lock_guard lock(mutex);
-    if (!errors.empty())
+
+    if (errors.empty())
+        return;
+
+    LOG_WARNING(log, "Has {} error requests", errors.size());
+
+    ///TODO error requests are not processed in sequence.
+    for (auto it = errors.begin(); it != errors.end();)
     {
-        LOG_WARNING(log, "Has {} error requests", errors.size());
-        for (auto it = errors.begin(); it != errors.end();)
+        auto [session_id, xid] = it->first;
+        auto & error_request = it->second;
+
+        auto & my_pending_requests = pending_requests.find(getRunnerId(session_id))->second;
+
+        /// request is not local
+        if (!keeper_dispatcher->isLocalSession(session_id))
         {
-            auto [session_id, xid] = it->first;
-            auto & error_request = it->second;
-
-            LOG_WARNING(log, "Try find error request session {}, xid {}, error code {}", toHexString(session_id), xid, error_request.error_code);
-
-            auto & pending_requests_for_thread = pending_requests.find(getRunnerId(session_id))->second;
-
-            if (!keeper_dispatcher->isLocalSession(session_id))
+            if (my_pending_requests.contains(session_id))
             {
-                if (pending_requests_for_thread.contains(session_id))
-                {
-                    LOG_WARNING(
-                        log,
-                        "Found session {} in pending_queue while it is not local, maybe because of connection disconnected. "
-                        "Just delete from pending queue",
-                        toHexString(session_id));
-                    pending_requests_for_thread.erase(session_id);
-                }
+                LOG_WARNING(
+                    log,
+                    "Found session {} in pending_queue while it is not local, maybe because of connection disconnected. "
+                    "Just delete from pending queue",
+                    toHexString(session_id));
+                my_pending_requests.erase(session_id);
+            }
 
-                LOG_WARNING(log, "Not my session error, session {}, xid {}", toHexString(session_id), xid);
+            LOG_WARNING(log, "Not my error request {}", error_request.toString());
+            it = errors.erase(it);
+        }
+        else
+        {
+            /// find error request in pending queue
+            std::optional<RequestForSession> request = findErrorRequest(error_request);
+
+            /// process error request
+            if (request)
+            {
+                LOG_ERROR(log, "Make error response for  {}", error_request.toString());
+
+                ZooKeeperResponsePtr response = request->request->makeResponse();
+                response->xid = request->request->xid;
+                response->zxid = 0;
+                response->request_created_time_ms = request->create_time;
+
+                response->error = error_request.error_code == nuraft::cmd_result_code::TIMEOUT ? Coordination::Error::ZOPERATIONTIMEOUT
+                                                                                               : Coordination::Error::ZCONNECTIONLOSS;
+
+                responses_queue.push(ResponseForSession{static_cast<int64_t>(session_id), response});
                 it = errors.erase(it);
             }
             else
             {
-                using namespace Coordination;
-                std::optional<RequestForSession> request;
-                if (static_cast<int32_t>(xid) == Coordination::AUTH_XID)
-                {
-                    ZooKeeperRequestPtr auth_request = std::make_shared<ZooKeeperAuthRequest>();
-                    using namespace std::chrono;
-                    int64_t now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-                    RequestForSession request1{auth_request, static_cast<int64_t>(session_id), now};
-                    request.emplace(request1);
-                }
-                else
-                {
-                    auto session_requests = pending_requests_for_thread.find(session_id);
-
-                    if (session_requests != pending_requests_for_thread.end())
-                    {
-                        auto & requests = session_requests->second;
-                        for (auto request_it = requests.begin(); request_it != requests.end();)
-                        {
-                            LOG_TRACE(
-                                log,
-                                "Try match session {} pending request xid {}, target error xid {}",
-                                toHexString(session_id),
-                                request_it->request->xid,
-                                xid);
-                            if (static_cast<uint64_t>(request_it->request->xid) < xid)
-                            {
-                                break;
-                            }
-                            else if (
-                                static_cast<uint64_t>(request_it->request->xid) == xid
-                                || (request_it->request->getOpNum() == Coordination::OpNum::Close
-                                    && error_request.opnum == Coordination::OpNum::Close))
-                            {
-                                request = *request_it;
-                                request_it = requests.erase(request_it);
-                                break;
-                            }
-                            else
-                            {
-                                ++request_it;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        LOG_WARNING(log, "Session {}, no pending requests", toHexString(session_id));
-                    }
-                }
-
-                if (request)
-                {
-                    ZooKeeperResponsePtr response = request->request->makeResponse();
-                    response->xid = request->request->xid;
-                    response->zxid = 0;
-                    response->request_created_time_ms = request->create_time;
-
-                    auto accepted = error_request.accepted;
-                    auto error_code = error_request.error_code;
-
-                    response->error = error_code == nuraft::cmd_result_code::TIMEOUT ? Coordination::Error::ZOPERATIONTIMEOUT
-                                                                                     : Coordination::Error::ZCONNECTIONLOSS;
-
-                    responses_queue.push(RK::KeeperStore::ResponseForSession{static_cast<int64_t>(session_id), response});
-
-                    LOG_ERROR(
-                        log,
-                        "Make error response for session {}, xid {}, opNum {}",
-                        toHexString(session_id),
-                        response->xid,
-                        error_request.opnum);
-
-                    if (!accepted)
-                        LOG_ERROR(log, "Request batch is not accepted");
-                    else
-                        LOG_ERROR(log, "Request batch error, nuraft code {}", error_code);
-
-                    LOG_ERROR(log, "Matched error request session {}, xid {} from pending requests queue", toHexString(session_id), xid);
-
-                    it = errors.erase(it);
-                }
-                else
-                {
-                    LOG_WARNING(
-                        log,
-                        "Not found error request session {}, xid {} from pending queue. Maybe it is still in the request queue "
-                        "and will be processed next time",
-                        toHexString(session_id),
-                        xid);
-                    break;
-                }
+                LOG_WARNING(
+                    this->log,
+                    "Not found error request {} in pending queue. Possible reason: 1.close requests from sessionCleanerTask are not put "
+                    "into pending queue; 2.error occurs(forward or append entries) but request is still committed, "
+                    "'processCommittedRequest' may delete request from pending request first, so here we can not find it. We also delete "
+                    "it from errors.",
+                    error_request.toString());
+                it = errors.erase(it);
             }
         }
     }
+}
+
+std::optional<RequestForSession> RequestProcessor::findErrorRequest(const ErrorRequest & error_request)
+{
+    auto session_id = error_request.session_id;
+    auto xid = error_request.xid;
+
+    /// Auth request is not put in pending queue, so no need to remove it.
+    if (xid == Coordination::AUTH_XID)
+    {
+        std::optional<RequestForSession> request;
+        ZooKeeperRequestPtr auth_request = std::make_shared<ZooKeeperAuthRequest>();
+
+        Poco::Timestamp timestamp;
+        auto now = timestamp.epochMicroseconds();
+
+        RequestForSession request_for_session{auth_request, session_id, now / 1000};
+        request.emplace(request_for_session);
+        return request;
+    }
+
+    std::optional<RequestForSession> request;
+
+    auto & my_pending_requests = pending_requests.find(getRunnerId(session_id))->second;
+    auto session_requests = my_pending_requests.find(session_id);
+
+    if (session_requests != my_pending_requests.end())
+    {
+        auto & requests = session_requests->second;
+        for (auto request_it = requests.begin(); request_it != requests.end();)
+        {
+            LOG_TRACE(log, "Try match {}", toHexString(session_id), request_it->request->xid);
+
+            if (request_it->request->xid == xid
+                || (request_it->request->getOpNum() == Coordination::OpNum::Close && error_request.opnum == Coordination::OpNum::Close))
+            {
+                request = *request_it;
+                request_it = requests.erase(request_it);
+                break;
+            }
+            else
+            {
+                ++request_it;
+            }
+        }
+    }
+
+    return request;
 }
 
 void RequestProcessor::processReadRequests(RunnerId runner_id)
@@ -399,42 +378,44 @@ void RequestProcessor::processReadRequests(RunnerId runner_id)
 
 void RequestProcessor::applyRequest(const RequestForSession & request) const
 {
+    LOG_TRACE(log, "Apply request {}", request.toSimpleString());
     try
     {
-        LOG_TRACE(
-            log,
-            "Apply request session {} xid {} request {}",
-            toHexString(request.session_id),
-            request.request->xid,
-            request.request->toString());
-
-        if (!server->isLeaderAlive() && request.request->isReadRequest())
+        if (request.request->isReadRequest())
         {
-            auto response = request.request->makeResponse();
+            if (server->isLeaderAlive())
+            {
+                server->getKeeperStateMachine()->getStore().processRequest(responses_queue, request);
+            }
+            else
+            {
+                auto response = request.request->makeResponse();
 
-            response->request_created_time_ms = request.create_time;
-            response->xid = request.request->xid;
-            response->zxid = 0;
-            response->error = Coordination::Error::ZCONNECTIONLOSS;
+                response->request_created_time_ms = request.create_time;
+                response->xid = request.request->xid;
+                response->zxid = 0;
+                response->error = Coordination::Error::ZCONNECTIONLOSS;
 
-            responses_queue.push(RK::KeeperStore::ResponseForSession{request.session_id, response});
+                responses_queue.push(ResponseForSession{request.session_id, response});
+            }
         }
-        /// Raft already committed the request, we must apply it/
         else
         {
             if (!server->isLeaderAlive())
-                LOG_WARNING(log, "Apply write request but leader not alive.");
-            server->getKeeperStateMachine()->getStore().processRequest(
-                responses_queue, request, {}, true, false);
+                LOG_WARNING(log, "Write request is committed, when try to apply it to store the leader is not alive.");
+            server->getKeeperStateMachine()->getStore().processRequest(responses_queue, request);
         }
     }
     catch (...)
     {
-        tryLogCurrentException(
-            log,
-            fmt::format(
-                "Got exception while process session {} read request {}.", toHexString(request.session_id), request.request->toString()));
+        tryLogCurrentException(log, fmt::format("Fail to apply request {}.", request.request->toString()));
+        if (!request.request->isReadRequest())
+        {
+            LOG_FATAL(log, "Fail to apply committed(write) request which will lead state machine inconsistency, system will exist.");
+            systemExist();
+        }
     }
+
 }
 
 void RequestProcessor::shutdown()
@@ -453,7 +434,7 @@ void RequestProcessor::shutdown()
     if (main_thread.joinable())
         main_thread.join();
 
-    KeeperStore::RequestForSession request_for_session;
+    RequestForSession request_for_session;
     while (requests_queue->tryPopAny(request_for_session))
     {
         auto response = request_for_session.request->makeResponse();
@@ -461,7 +442,7 @@ void RequestProcessor::shutdown()
         response->zxid = 0;
         response->request_created_time_ms = request_for_session.create_time;
         response->error = Coordination::Error::ZSESSIONEXPIRED;
-        responses_queue.push(RK::KeeperStore::ResponseForSession{request_for_session.session_id, response});
+        responses_queue.push(ResponseForSession{request_for_session.session_id, response});
     }
 }
 
@@ -483,11 +464,13 @@ void RequestProcessor::onError(
 {
     if (!shutdown_called)
     {
-        LOG_WARNING(log, "On error session {}, xid {}", toHexString(session_id), xid);
+        RequestId id{session_id, xid};
+        ErrorRequest error_request{accepted, error_code, session_id, xid, opnum};
+
+        LOG_WARNING(log, "On error request ", error_request.toString());
         {
-            std::unique_lock lk(mutex);
-            ErrorRequest error_request{accepted, error_code, session_id, xid, opnum};
-            errors.emplace(UInt128(session_id, xid), error_request);
+            std::unique_lock lock(mutex);
+            errors.emplace(id, error_request);
         }
         cv.notify_all();
     }

--- a/src/Service/RequestProcessor.h
+++ b/src/Service/RequestProcessor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ZooKeeper/ZooKeeperConstants.h"
 #include <Service/KeeperServer.h>
 #include <Service/RequestsQueue.h>
 #include <Service/Types.h>
@@ -7,17 +8,6 @@
 
 namespace RK
 {
-
-using RequestForSession = KeeperStore::RequestForSession;
-
-struct ErrorRequest
-{
-    bool accepted;
-    nuraft::cmd_result_code error_code;
-    int64_t session_id;
-    Coordination::XID xid;
-    Coordination::OpNum opnum;
-};
 
 class KeeperDispatcher;
 
@@ -32,21 +22,12 @@ public:
     }
 
     void push(const RequestForSession & request_for_session);
-    void run();
-
-    void moveRequestToPendingQueue(RunnerId runner_id);
-
-    void processReadRequests(RunnerId runner_id);
-    void processErrorRequest();
-    void processCommittedRequest(size_t count);
-
-    /// Apply request to state machine
-    void applyRequest(const RequestForSession & request) const;
 
     void shutdown();
 
     void commit(RequestForSession request);
 
+    /// Invoked when fail to forward request to leader or append entry.
     void onError(bool accepted, nuraft::cmd_result_code error_code, int64_t session_id, Coordination::XID xid, Coordination::OpNum opnum);
 
     void initialize(
@@ -58,10 +39,29 @@ public:
     size_t commitQueueSize() { return committed_queue.size(); }
 
 private:
+    void run();
+    /// Exist system for fatal error.
+    [[noreturn]] void systemExist() const;
+
+    void moveRequestToPendingQueue(RunnerId runner_id);
+
+    void processReadRequests(RunnerId runner_id);
+    void processErrorRequest();
+    void processCommittedRequest(size_t count);
+
+    /// Apply request to state machine
+    void applyRequest(const RequestForSession & request) const;
     size_t getRunnerId(int64_t session_id) const { return session_id % runner_count; }
 
+    /// Find error request in pending request queue
+    std::optional<RequestForSession> findErrorRequest(const ErrorRequest & error_request);
 
-    using RequestForSessions = std::vector<KeeperStore::RequestForSession>;
+    /// We can handle zxid as a continuous stream of committed(write) requests at once.
+    /// However, if we encounter a read request or an erroneous request,
+    /// we need to interrupt the processing.
+    bool shouldProcessCommittedRequest(const RequestForSession & committed_request, bool & found_in_pending_queue);
+
+    using RequestForSessions = std::vector<RequestForSession>;
 
     ThreadFromGlobalPool main_thread;
 
@@ -79,7 +79,7 @@ private:
     std::unordered_map<size_t, std::unordered_map<int64_t, RequestForSessions>> pending_requests;
 
     /// Raft committed write requests which can be local or from other nodes.
-    ConcurrentBoundedQueue<KeeperStore::RequestForSession> committed_queue{1000};
+    ConcurrentBoundedQueue<RequestForSession> committed_queue{1000};
 
     size_t runner_count;
 
@@ -92,7 +92,7 @@ private:
 
     /// key : session_id xid
     /// Error requests when append entry or forward to leader
-    std::unordered_map<UInt128, ErrorRequest> errors;
+    std::unordered_map<RequestId, ErrorRequest, RequestId::RequestIdHash> errors;
 
     Poco::Logger * log;
 

--- a/src/Service/RequestProcessor.h
+++ b/src/Service/RequestProcessor.h
@@ -46,7 +46,7 @@ private:
     void moveRequestToPendingQueue(RunnerId runner_id);
 
     void processReadRequests(RunnerId runner_id);
-    void processErrorRequest();
+    void processErrorRequest(size_t count);
     void processCommittedRequest(size_t count);
 
     /// Apply request to state machine
@@ -90,9 +90,10 @@ private:
     mutable std::mutex mutex;
     std::condition_variable cv;
 
-    /// key : session_id xid
-    /// Error requests when append entry or forward to leader
-    std::unordered_map<RequestId, ErrorRequest, RequestId::RequestIdHash> errors;
+    /// Error requests when append entry or forward to leader.
+    ErrorRequests error_requests;
+    /// Used as index for error_requests
+    std::unordered_set<RequestId, RequestId::RequestIdHash> error_request_ids;
 
     Poco::Logger * log;
 

--- a/src/Service/RequestsQueue.h
+++ b/src/Service/RequestsQueue.h
@@ -35,7 +35,7 @@ namespace RK
  */
 struct RequestsQueue
 {
-    using Queue = ConcurrentBoundedQueue<KeeperStore::RequestForSession>;
+    using Queue = ConcurrentBoundedQueue<RequestForSession>;
 
     std::vector<ptr<Queue>> queues;
 
@@ -63,26 +63,26 @@ struct RequestsQueue
         return queues[request.session_id % queues.size()]->tryPush(std::forward<Request>(request), wait_ms);
     }
 
-    bool pop(size_t queue_id, KeeperStore::RequestForSession & request)
+    bool pop(size_t queue_id, RequestForSession & request)
     {
         assert(queue_id != 0 && queue_id <= queues.size());
         return queues[queue_id]->pop(request);
     }
 
-    bool tryPop(size_t queue_id, KeeperStore::RequestForSession & request, UInt64 wait_ms = 0)
+    bool tryPop(size_t queue_id, RequestForSession & request, UInt64 wait_ms = 0)
     {
         assert(queue_id < queues.size());
         return queues[queue_id]->tryPop(request, wait_ms);
     }
 
-    [[maybe_unused]] bool tryPopMicro(size_t queue_id, KeeperStore::RequestForSession & request, UInt64 wait_micro = 0)
+    [[maybe_unused]] bool tryPopMicro(size_t queue_id, RequestForSession & request, UInt64 wait_micro = 0)
     {
         assert(queue_id < queues.size());
         return queues[queue_id]->tryPopMicro(request, wait_micro);
     }
 
 
-    bool tryPopAny(KeeperStore::RequestForSession & request, UInt64 wait_ms = 0)
+    bool tryPopAny(RequestForSession & request, UInt64 wait_ms = 0)
     {
         for (const auto & queue : queues)
         {

--- a/src/Service/tests/gtest_raft_log.cpp
+++ b/src/Service/tests/gtest_raft_log.cpp
@@ -1,13 +1,15 @@
-#include <Service/KeeperCommon.h>
+#include <Poco/File.h>
+
+#include <boost/program_options.hpp>
+#include <common/argsToConfig.h>
+#include <gtest/gtest.h>
+#include <libnuraft/nuraft.hxx>
+
+#include <Service/KeeperUtils.h>
 #include <Service/NuRaftFileLogStore.h>
 #include <Service/NuRaftLogSegment.h>
 #include <Service/proto/Log.pb.h>
 #include <Service/tests/raft_test_common.h>
-#include <boost/program_options.hpp>
-#include <gtest/gtest.h>
-#include <libnuraft/nuraft.hxx>
-#include <Poco/File.h>
-#include <common/argsToConfig.h>
 
 
 using namespace nuraft;

--- a/src/Service/tests/gtest_raft_performance.cpp
+++ b/src/Service/tests/gtest_raft_performance.cpp
@@ -1,14 +1,16 @@
-#include <Service/KeeperCommon.h>
+#include <Poco/File.h>
+
+#include <Common/Stopwatch.h>
+#include <common/argsToConfig.h>
+#include <gtest/gtest.h>
+#include <libnuraft/nuraft.hxx>
+
+#include <Service/KeeperUtils.h>
 #include <Service/NuRaftFileLogStore.h>
 #include <Service/NuRaftLogSegment.h>
 #include <Service/NuRaftStateMachine.h>
 #include <Service/proto/Log.pb.h>
 #include <Service/tests/raft_test_common.h>
-#include <gtest/gtest.h>
-#include <libnuraft/nuraft.hxx>
-#include <Poco/File.h>
-#include <Common/Stopwatch.h>
-#include <common/argsToConfig.h>
 
 using namespace nuraft;
 using namespace RK;

--- a/src/Service/tests/gtest_raft_snapshot.cpp
+++ b/src/Service/tests/gtest_raft_snapshot.cpp
@@ -2,6 +2,7 @@
 #include <unordered_map>
 #include <Service/ACLMap.h>
 #include <Service/KeeperStore.h>
+#include <Service/KeeperCommon.h>
 #include <Service/NuRaftFileLogStore.h>
 #include <Service/NuRaftLogSegment.h>
 #include <Service/NuRaftLogSnapshot.h>
@@ -62,7 +63,7 @@ ptr<buffer> closeSessionLog(int64_t session_id)
 {
     Coordination::ZooKeeperRequestPtr request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
     request->xid = Coordination::CLOSE_XID;
-    KeeperStore::RequestForSession request_info;
+    RequestForSession request_info;
     request_info.request = request;
     request_info.session_id = session_id;
     int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
@@ -80,7 +81,7 @@ ptr<buffer> createLog(int64_t session_id, const std::string & key, const std::st
     acl.id = "anyone";
     default_acls.emplace_back(std::move(acl));
 
-    auto session_request = cs_new<KeeperStore::RequestForSession>();
+    auto session_request = cs_new<RequestForSession>();
     auto request = cs_new<ZooKeeperCreateRequest>();
     session_request->request = request;
     session_request->session_id = session_id;
@@ -107,7 +108,7 @@ ptr<buffer> setLog(int64_t session_id, const std::string & key, const std::strin
     acl.id = "anyone";
     default_acls.emplace_back(std::move(acl));
 
-    auto session_request = cs_new<KeeperStore::RequestForSession>();
+    auto session_request = cs_new<RequestForSession>();
     auto request = cs_new<ZooKeeperSetRequest>();
     session_request->request = request;
     session_request->session_id = session_id;
@@ -132,7 +133,7 @@ ptr<buffer> removeLog(int64_t session_id, const std::string & key)
     acl.id = "anyone";
     default_acls.emplace_back(std::move(acl));
 
-    auto session_request = cs_new<KeeperStore::RequestForSession>();
+    auto session_request = cs_new<RequestForSession>();
     auto request = cs_new<ZooKeeperRemoveRequest>();
     session_request->request = request;
     session_request->session_id = session_id;
@@ -227,7 +228,7 @@ ACLs getACL(KeeperStore & storage, const std::string key)
     int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
     storage.processRequest(responses_queue, {request, 1, time}, {}, /* check_acl = */ true, /*ignore_response*/ false);
 
-    KeeperStore::ResponseForSession responses;
+    ResponseForSession responses;
     responses_queue.tryPop(responses);
     return dynamic_cast<Coordination::ZooKeeperGetACLResponse &>(*responses.response).acl;
 }

--- a/src/Service/tests/gtest_raft_state_machine.cpp
+++ b/src/Service/tests/gtest_raft_state_machine.cpp
@@ -2,6 +2,7 @@
 #include <Service/NuRaftFileLogStore.h>
 #include <Service/NuRaftLogSegment.h>
 #include <Service/NuRaftStateMachine.h>
+#include <Service/KeeperCommon.h>
 #include <Service/tests/raft_test_common.h>
 #include <gtest/gtest.h>
 #include <libnuraft/nuraft.hxx>
@@ -39,7 +40,7 @@ void createZNodeLog(NuRaftStateMachine & machine, std::string & key, std::string
     default_acls.emplace_back(std::move(acl));
 
     UInt64 index = machine.last_commit_index() + 1;
-    KeeperStore::RequestForSession session_request;
+    RequestForSession session_request;
     session_request.session_id = createSession(machine);
     auto request = cs_new<ZooKeeperCreateRequest>();
     session_request.request = request;
@@ -81,7 +82,7 @@ void setZNode(NuRaftStateMachine & machine, std::string & key, std::string & dat
     default_acls.emplace_back(std::move(acl));
 
     UInt64 index = machine.last_commit_index() + 1;
-    KeeperStore::RequestForSession session_request;
+    RequestForSession session_request;
     session_request.session_id = createSession(machine);
     auto request = cs_new<ZooKeeperSetRequest>();
     session_request.request = request;
@@ -108,7 +109,7 @@ void removeZNode(NuRaftStateMachine & machine, std::string & key)
     default_acls.emplace_back(std::move(acl));
 
     UInt64 index = machine.last_commit_index() + 1;
-    KeeperStore::RequestForSession session_request;
+    RequestForSession session_request;
     session_request.session_id = createSession(machine);
     auto request = cs_new<ZooKeeperRemoveRequest>();
     session_request.request = request;
@@ -139,7 +140,7 @@ TEST(RaftStateMachine, serializeAndParse)
     default_acls.emplace_back(std::move(acl));
 
     //UInt64 index = machine.last_commit_index() + 1;
-    KeeperStore::RequestForSession session_request;
+    RequestForSession session_request;
     session_request.session_id = 1;
     auto request = cs_new<ZooKeeperCreateRequest>();
     request->path = "1";
@@ -153,7 +154,7 @@ TEST(RaftStateMachine, serializeAndParse)
     session_request.create_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 
     ptr<buffer> buf = NuRaftStateMachine::serializeRequest(session_request);
-    KeeperStore::RequestForSession session_request_2 = NuRaftStateMachine::parseRequest(*(buf.get()));
+    RequestForSession session_request_2 = NuRaftStateMachine::parseRequest(*(buf.get()));
     if (session_request_2.request->getOpNum() == OpNum::Create)
     {
         ZooKeeperCreateRequest * request_2 = static_cast<ZooKeeperCreateRequest *>(session_request_2.request.get());

--- a/src/Service/tests/raft_unit_benchmark.cpp
+++ b/src/Service/tests/raft_unit_benchmark.cpp
@@ -2,22 +2,25 @@
 #include <memory>
 #include <string>
 #include <time.h>
-#include <Service/KeeperCommon.h>
+
+#include <Poco/File.h>
+#include <Poco/Util/Application.h>
+
+#include <Common/Stopwatch.h>
+#include <Common/ThreadPool.h>
+#include <Common/randomSeed.h>
+#include <boost/program_options.hpp>
+#include <common/argsToConfig.h>
+#include <libnuraft/nuraft.hxx>
+#include <loggers/Loggers.h>
+
+#include <Service/KeeperUtils.h>
 #include <Service/LogEntry.h>
 #include <Service/NuRaftLogSegment.h>
 #include <Service/NuRaftLogSnapshot.h>
 #include <Service/Settings.h>
 #include <ZooKeeper/IKeeper.h>
 #include <ZooKeeper/ZooKeeperImpl.h>
-#include <boost/program_options.hpp>
-#include <libnuraft/nuraft.hxx>
-#include <loggers/Loggers.h>
-#include <Poco/File.h>
-#include <Poco/Util/Application.h>
-#include <Common/Stopwatch.h>
-#include <Common/ThreadPool.h>
-#include <Common/randomSeed.h>
-#include <common/argsToConfig.h>
 
 using namespace Coordination;
 using namespace RK;


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #89 

### Change log:
<!-- (Please describe the changes you have made in details. -->
1. Add `KeeperCommon.h` which contains common prototypes such as `RequestForSession`
2. Rename `KeeperCommon.h` to `KeeperUtils.h`
3. Add `RequestId` instead of UInt28(session_id, xid)
4. Fix request processor endless loop
5. `sessionCleanerTask` will not `finishSession`
6. Some code refactoring.