### PR TITLE
add cluster_config_lock_ to avoid data race

### DIFF
--- a/src/Service/KeeperServer.cpp
+++ b/src/Service/KeeperServer.cpp
@@ -332,7 +332,7 @@ bool KeeperServer::isLeader() const
 
 bool KeeperServer::isObserver() const
 {
-    auto cluster_config = state_manager->get_cluster_config();
+    auto cluster_config = state_manager->getClusterConfig();
     return cluster_config->get_server(server_id)->is_learner();
 }
 

--- a/src/Service/NuRaftStateManager.h
+++ b/src/Service/NuRaftStateManager.h
@@ -66,7 +66,9 @@ public:
 
     //ptr<srv_config> get_srv_config() const { return curr_srv_config; }
 
-    ptr<cluster_config> get_cluster_config() const { return cur_cluster_config; }
+    ptr<cluster_config> get_cluster_config() const;
+
+    void set_cluster_config(const ptr<cluster_config>& new_config);
 
     /// Get configuration diff between proposed XML and current state in RAFT
     ConfigUpdateActions getConfigurationDiff(const Poco::Util::AbstractConfiguration & config);
@@ -87,6 +89,12 @@ private:
     ptr<log_store> curr_log_store;
 
     ptr<cluster_config> cur_cluster_config;
+
+    /**
+     * Lock for cluster config.
+     */
+    mutable std::mutex cluster_config_lock_;
+
 
 protected:
     Poco::Logger * log;

--- a/src/Service/NuRaftStateManager.h
+++ b/src/Service/NuRaftStateManager.h
@@ -66,9 +66,9 @@ public:
 
     //ptr<srv_config> get_srv_config() const { return curr_srv_config; }
 
-    ptr<cluster_config> get_cluster_config() const;
+    ptr<cluster_config> getClusterConfig() const;
 
-    void set_cluster_config(const ptr<cluster_config>& new_config);
+    void setClusterConfig(const ptr<cluster_config>& new_config);
 
     /// Get configuration diff between proposed XML and current state in RAFT
     ConfigUpdateActions getConfigurationDiff(const Poco::Util::AbstractConfiguration & config);
@@ -93,7 +93,7 @@ private:
     /**
      * Lock for cluster config.
      */
-    mutable std::mutex cluster_config_lock_;
+    mutable std::mutex cluster_config_mutex;
 
 
 protected:


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #104

### Change log:
add cluster_config_lock_ to avoid data race

