### PR TITLE
Fix too much warning log

### DIFF
--- a/src/Service/ConnectionHandler.cpp
+++ b/src/Service/ConnectionHandler.cpp
@@ -638,7 +638,6 @@ void ConnectionHandler::sendResponse(const Coordination::ZooKeeperResponsePtr & 
 {
     LOG_TRACE(log, "Dispatch response {} to conn handler session {}", response->toString(), toHexString(session_id));
 
-    /// TODO should invoked after response sent to client.
     updateStats(response);
 
     /// We do not need send anything for close request to client.

--- a/src/Service/RequestProcessor.cpp
+++ b/src/Service/RequestProcessor.cpp
@@ -195,12 +195,6 @@ void RequestProcessor::processCommittedRequest(size_t count)
                 my_pending_requests.erase(committed_request.session_id);
             }
 
-            LOG_WARNING(
-                log,
-                "Session {} is not local, maybe it is because of disconnecting. We still should apply the committed(write) "
-                "request",
-                committed_request.session_id);
-
             applyRequest(committed_request);
             committed_queue.pop();
         }
@@ -209,7 +203,7 @@ void RequestProcessor::processCommittedRequest(size_t count)
         {
             if (committed_request.request->getOpNum() == Coordination::OpNum::Auth)
             {
-                LOG_DEBUG(log, "Apply auth request", committed_request.session_id);
+                LOG_DEBUG(log, "Apply auth request {}", toHexString(committed_request.session_id));
                 applyRequest(committed_request);
                 committed_queue.pop();
             }


### PR DESCRIPTION
### Change log:
<!-- (Please describe the changes you have made in details. -->

Fix too much useless warning log

```
2023.11.22 18:51:30.436301 [ 85 ] <Warning> RequestProcessor: Session 8275883 is not local, maybe it is because of disconnecting. We still should apply the committed(write) request
2023.11.22 18:51:30.475215 [ 85 ] <Warning> RequestProcessor: Session 8275885 is not local, maybe it is because of disconnecting. We still should apply the committed(write) request
2023.11.22 18:51:30.484399 [ 85 ] <Warning> RequestProcessor: Session 8275859 is not local, maybe it is because of disconnecting. We still should apply the committed(write) request
2023.11.22 18:51:30.487140 [ 85 ] <Warning> RequestProcessor: Session 8275885 is not local, maybe it is because of disconnecting. We still should apply the committed(write) request
2023.11.22 18:51:30.488113 [ 85 ] <Warning> RequestProcessor: Session 8275885 is not local, maybe it is because of disconnecting. We still should apply the committed(write) request
2023.11.22 18:51:30.489006 [ 85 ] <Warning> RequestProcessor: Session 8275885 is not local, maybe it is because of disconnecting. We still should apply the committed(write) reques
```