### PR TITLE
Adjust raft timeout

### DIFF
--- a/src/Service/KeeperServer.cpp
+++ b/src/Service/KeeperServer.cpp
@@ -54,12 +54,14 @@ namespace
         params.election_timeout_upper_bound_ = raft_settings->election_timeout_upper_bound_ms;
         params.reserved_log_items_ = raft_settings->reserved_log_items;
         params.snapshot_distance_ = raft_settings->snapshot_distance;
-        params.client_req_timeout_ = raft_settings->operation_timeout_ms;
         params.return_method_ = nuraft::raft_params::blocking;
         params.parallel_log_appending_ = raft_settings->log_fsync_mode == FsyncMode::FSYNC_PARALLEL;
+        /// TODO disable auto_forwarding_
         params.auto_forwarding_ = true;
-        params.auto_forwarding_req_timeout_ = raft_settings->operation_timeout_ms;
-        // TODO set max_batch_size to NuRaft
+        /// forwarding timeout should lower than operation_timeout_ms
+        params.auto_forwarding_req_timeout_ = std::max(raft_settings->operation_timeout_ms - 1000, raft_settings->operation_timeout_ms / 2);
+        /// client_req_timeout_ should lower than auto_forwarding_req_timeout_
+        params.client_req_timeout_ = std::max(params.auto_forwarding_req_timeout_ - 1000, params.auto_forwarding_req_timeout_ / 2);
     }
 }
 

--- a/src/ZooKeeper/ZooKeeperConstants.h
+++ b/src/ZooKeeper/ZooKeeperConstants.h
@@ -36,8 +36,8 @@ enum class OpNum : int32_t
     MultiRead = 22,
     Auth = 100,
     SetWatches = 101,
-    SessionID = 997, /// Special raftkeeper internal request. Used to get session id.
-    UpdateSession = 996, /// Special raftkeeper internal request. Used to session reconnect.
+    SessionID = 997, /// Special internal request. Used to get session id.
+    UpdateSession = 996, /// Special internal request. Used to session reconnect.
 };
 
 std::string toString(OpNum op_num);
@@ -55,6 +55,6 @@ static constexpr int32_t MAX_STRING_OR_ARRAY_SIZE = 1 << 28; /// 256 MiB
 static constexpr int32_t DEFAULT_SESSION_TIMEOUT_MS = 30000;
 static constexpr int32_t DEFAULT_MIN_SESSION_TIMEOUT_MS = 10000;
 static constexpr int32_t DEFAULT_MAX_SESSION_TIMEOUT_MS = 100000;
-static constexpr int32_t DEFAULT_OPERATION_TIMEOUT_MS = 2000;
+static constexpr int32_t DEFAULT_OPERATION_TIMEOUT_MS = 10000;
 
 }


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #124 

### Change log:
<!-- (Please describe the changes you have made in details. -->
1. defatul `operation_timeout_ms`= 20000
2. `client_req_timeout_` < `auto_forwarding_req_timeout_` < `operation_timeout_ms`
