### PR TITLE
Fix illegal reconnection

### DIFF
--- a/src/Service/ConnectionHandler.h
+++ b/src/Service/ConnectionHandler.h
@@ -138,7 +138,7 @@ private:
     /// Default session_id is 0, so if a connection failed,
     /// server will return 0 and when client tries connect
     /// with previous_session_id = 0.
-    /// Server receives the 0 and will identify it as a re-connection.
+    /// Server receives the 0 and will not identify it as a re-connection.
     int64_t session_id{0};
 
     Stopwatch session_stopwatch;

--- a/src/Service/ConnectionHandler.h
+++ b/src/Service/ConnectionHandler.h
@@ -135,7 +135,11 @@ private:
     Poco::Timespan min_session_timeout;
     Poco::Timespan max_session_timeout;
 
-    int64_t session_id{-1};
+    /// Default session_id is 0, so if a connection failed,
+    /// server will return 0 and when client tries connect
+    /// with previous_session_id = 0.
+    /// Server receives the 0 and will identify it as a re-connection.
+    int64_t session_id{0};
 
     Stopwatch session_stopwatch;
     ThreadSafeResponseQueuePtr responses;

--- a/tests/integration/test_four_word_command/test.py
+++ b/tests/integration/test_four_word_command/test.py
@@ -436,12 +436,20 @@ def test_cmd_crst(started_cluster):
         print(data)
 
         data = node1.send_4lw_cmd(cmd='cons')
+        print("cons output -------------------------------------")
+        print(data)
 
         # 2 connections, 1 for 'cons' command, 1 for zk
         cons = [n for n in data.split('\n') if len(n) > 0]
         assert len(cons) == 2
 
-        conn_stat = re.match(r'(.*?)[:].*[(](.*?)[)].*', cons[0].strip(), re.S).group(2)
+        zk_con = None
+        if 'sid' in cons[0]:
+            zk_con = cons[0]
+        else:
+            zk_con = cons[1]
+
+        conn_stat = re.match(r'(.*?)[:].*[(](.*?)[)].*', zk_con.strip(), re.S).group(2)
         assert conn_stat is not None
 
         result = {}


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #121

### Change log:
<!-- (Please describe the changes you have made in details. -->

If default session_id is -1, when a connection failed, server will return -1 and when client tries re-connect with previous_session_id = -1. Server receives the -1 and will identify it as a re-connection.

But actually it is not re-connection because it never success.