### PR TITLE
Set default dead_session_check_period_ms to 500

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -71,8 +71,8 @@
             <!-- User operation timeout in millisecond, default is 2000. -->
             <!-- <operation_timeout_ms>2000</operation_timeout_ms> -->
 
-            <!-- Leader will check whether session is dead in this period, default is 1000. -->
-            <!-- <dead_session_check_period_ms>100</dead_session_check_period_ms> -->
+            <!-- Leader will check whether session is dead in this period, default is 500. -->
+            <!-- <dead_session_check_period_ms>500</dead_session_check_period_ms> -->
 
             <!-- NuRaft heart beat interval in millisecond, default is 500. -->
             <!-- <heart_beat_interval_ms>500</heart_beat_interval_ms> -->

--- a/src/Service/KeeperDispatcher.cpp
+++ b/src/Service/KeeperDispatcher.cpp
@@ -241,7 +241,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
         throw;
     }
 
-    UInt64 session_sync_period_ms = configuration_and_settings->raft_settings->dead_session_check_period_ms / 2;
+    UInt64 session_sync_period_ms = configuration_and_settings->raft_settings->dead_session_check_period_ms * 2;
     request_forwarder.initialize(thread_count, server, shared_from_this(), session_sync_period_ms, operation_timeout_ms);
     request_accumulator.initialize(
         1, shared_from_this(), server, operation_timeout_ms, configuration_and_settings->raft_settings->max_batch_size);

--- a/src/Service/RequestForwarder.h
+++ b/src/Service/RequestForwarder.h
@@ -27,9 +27,6 @@ public:
     void push(const RequestForSession & request_for_session);
 
     void runSend(RunnerId runner_id);
-
-    void shutdown();
-
     void runReceive(RunnerId runner_id);
 
     void initialize(
@@ -39,33 +36,28 @@ public:
         UInt64 session_sync_period_ms_,
         UInt64 operation_timeout_ms_);
 
+    void shutdown();
 
-public:
     std::shared_ptr<RequestProcessor> request_processor;
-
     std::shared_ptr<KeeperDispatcher> keeper_dispatcher;
 
 private:
+    void initConnections();
 
-    void runSessionSync(RunnerId runner_id);
-    void runSessionSyncReceive(RunnerId runner_id);
+    /// void runSessionSync(RunnerId runner_id);
+    /// void runSessionSyncReceive(RunnerId runner_id);
 
     void processResponse(RunnerId runner_id, ForwardResponsePtr forward_response_ptr);
-
     bool removeFromQueue(RunnerId runner_id, ForwardResponsePtr forward_response_ptr);
 
     bool processTimeoutRequest(RunnerId runner_id, ForwardRequestPtr newFront);
 
-    void initConnections();
-
     size_t thread_count;
-
     ptr<RequestsQueue> requests_queue;
 
     Poco::Logger * log;
 
     ThreadPoolPtr request_thread;
-
     ThreadPoolPtr response_thread;
 
     ThreadFromGlobalPool session_sync_thread;
@@ -74,10 +66,8 @@ private:
 
     std::shared_ptr<KeeperServer> server;
 
-    UInt64 session_sync_period_ms = 500;
-
+    UInt64 session_sync_period_ms;
     std::atomic<UInt64> session_sync_idx{0};
-
     Stopwatch session_sync_time_watch;
 
     using ForwardingQueue = ThreadSafeQueue<ForwardRequestPtr, std::list<ForwardRequestPtr>>;
@@ -86,9 +76,9 @@ private:
 
     Poco::Timespan operation_timeout;
 
-    std::mutex connections_mutex;
     using ConnectionPool = std::vector<ptr<ForwardingConnection>>;
     std::unordered_map<UInt32, ConnectionPool> connections;
+    std::mutex connections_mutex;
 
     using EndPoint = String; /// host:port
     std::unordered_map<UInt32, EndPoint> cluster_config_forward;

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -69,7 +69,7 @@ void RaftSettings::loadFromConfig(const String & config_elem, const Poco::Util::
             max_session_timeout_ms = Coordination::DEFAULT_MAX_SESSION_TIMEOUT_MS;
             min_session_timeout_ms = Coordination::DEFAULT_MIN_SESSION_TIMEOUT_MS;
         }
-        dead_session_check_period_ms = config.getUInt(get_key("dead_session_check_period_ms"), 100);
+        dead_session_check_period_ms = config.getUInt(get_key("dead_session_check_period_ms"), 500);
         heart_beat_interval_ms = config.getUInt(get_key("heart_beat_interval_ms"), 500);
         election_timeout_lower_bound_ms = config.getUInt(get_key("election_timeout_lower_bound_ms"), 10000);
         election_timeout_upper_bound_ms = config.getUInt(get_key("election_timeout_upper_bound_ms"), 20000);
@@ -104,7 +104,7 @@ RaftSettingsPtr RaftSettings::getDefault()
     settings->max_session_timeout_ms = Coordination::DEFAULT_MAX_SESSION_TIMEOUT_MS;
     settings->min_session_timeout_ms = Coordination::DEFAULT_MIN_SESSION_TIMEOUT_MS;
     settings->operation_timeout_ms = Coordination::DEFAULT_OPERATION_TIMEOUT_MS;
-    settings->dead_session_check_period_ms = 100;
+    settings->dead_session_check_period_ms = 500;
     settings->heart_beat_interval_ms = 500;
     settings->election_timeout_lower_bound_ms = 10000;
     settings->election_timeout_upper_bound_ms = 20000;

--- a/tests/integration/test_four_word_command/test.py
+++ b/tests/integration/test_four_word_command/test.py
@@ -254,7 +254,7 @@ def test_cmd_conf(started_cluster):
         assert result["min_session_timeout_ms"] == "1000"
         assert result["max_session_timeout_ms"] == "30000"
         assert result["operation_timeout_ms"] == "1000"
-        assert result["dead_session_check_period_ms"] == "100"
+        assert result["dead_session_check_period_ms"] == "500"
         assert result["heart_beat_interval_ms"] == "500"
         assert result["election_timeout_lower_bound_ms"] == "5000"
         assert result["election_timeout_upper_bound_ms"] == "10000"


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #127 

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Set default`dead_session_check_period_ms` to 500
- Set session_sync to 2 * `dead_session_check_period_ms`
