### PR TITLE
Fix watch not triggered for `muilt` request

### DIFF
--- a/src/Service/KeeperStore.cpp
+++ b/src/Service/KeeperStore.cpp
@@ -1539,7 +1539,8 @@ void KeeperStore::processRequest(
                 std::lock_guard lock(watch_mutex);
 
                 /// handle watch trigger, below 1 and 2 must be atomic
-                if (watches.contains(zk_request->getPath()) || list_watches.contains(parentPath(zk_request->getPath())))
+                if (zk_request->getOpNum() == Coordination::OpNum::Multi || watches.contains(zk_request->getPath())
+                    || list_watches.contains(parentPath(zk_request->getPath())))
                 {
                     if (response->error == Coordination::Error::ZOK)
                     {


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #129

### Change log:
<!-- (Please describe the changes you have made in details. -->
Fix handle watch trigger in `muilt` ops