### PR TITLE
Enable creating RaftKeeper snapshot logs for Converter

### DIFF
--- a/programs/converter/RaftKeeperConverter.cpp
+++ b/programs/converter/RaftKeeperConverter.cpp
@@ -29,6 +29,7 @@ int mainEntryRaftKeeperConverter(int argc, char ** argv)
 
     Poco::Logger * logger = &Poco::Logger::get("RaftKeeperConverter");
     logger->setChannel(console_channel);
+    logger->root().setChannel(console_channel);
 
     if (options.count("help"))
     {


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #150

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Enable creating RaftKeeper snapshot logs for Converter


### Output

```
Create snapshot last_log_term 1, last_log_idx 3, size 5, nodes 5, ephemeral nodes 0, sessions 0, session_id_counter 0, zxid 0
Creating snapshot with approximately data_object_count 1, total_obj_count 4, next zxid 0, next session id 0
Begin create snapshot map object, map size 2, path /var/lib/raftkeeper/data/raft_snapshot/snapshot_20240104014721_3_1
Begin create snapshot session object, session size 0, path /var/lib/raftkeeper/data/raft_snapshot/snapshot_20240104014721_3_2
Creating snapshot nex_session_id 0x0, serialized_next_session_id 0x1
Begin create snapshot acl object, acl size 2, path /var/lib/raftkeeper/data/raft_snapshot/snapshot_20240104014721_3_3
Create new snapshot object 4, path /var/lib/raftkeeper/data/raft_snapshot/snapshot_20240104014721_3_4
Creating snapshot processed data size 5, current zxid 3
Creating snapshot real data_object_count 1, total_obj_count 4
```