### PR TITLE
Print timezone for built time in command mntr

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -20,7 +20,7 @@ endif ()
 find_program(DATE_CMD NAMES date)
 if (DATE_CMD)
     execute_process(
-            COMMAND ${DATE_CMD} "+%Y-%m-%d %H:%M:%S"
+            COMMAND ${DATE_CMD} "+%Y-%m-%d %H:%M:%S %Z"
             OUTPUT_VARIABLE BUILD_TIME
             OUTPUT_STRIP_TRAILING_WHITESPACE
     )

--- a/src/Service/FourLetterCommand.cpp
+++ b/src/Service/FourLetterCommand.cpp
@@ -12,8 +12,6 @@
 #include <Common/config_version.h>
 #include <Common/getCurrentProcessFDCount.h>
 #include <Common/getMaxFileDescriptorCount.h>
-#include <common/find_symbols.h>
-#include <common/logger_useful.h>
 
 #include <unistd.h>
 
@@ -168,7 +166,7 @@ void FourLetterCommandFactory::initializeWhiteList(KeeperDispatcher & keeper_dis
     Strings tokens;
     splitInto<','>(tokens, list_str);
 
-    for (String token: tokens)
+    for (const String& token: tokens)
     {
         Poco::trim(token);
 


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #153

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Print timezone for built time in command mntr

Now the output like

```
zk_version	RaftKeeper v2.0.4-64c4aebac275e4d1d9e8140c09c6599b4be968b1, built on 2024-01-03 14:56:51 CST
```