### PR TITLE
Avoid memory copy when parsing log

### DIFF
--- a/src/Service/LogEntry.cpp
+++ b/src/Service/LogEntry.cpp
@@ -22,16 +22,13 @@ ptr<buffer> LogEntryBody::serialize(ptr<log_entry> & entry)
     return entry_buf;
 }
 
-ptr<log_entry> LogEntryBody::parse(const char * entry_str, const UInt64 & term, size_t buf_size)
+ptr<log_entry> LogEntryBody::parse(const char * entry_str, size_t buf_size)
 {
-    auto entry_buf = buffer::alloc(buf_size);
-    entry_buf->put_raw(reinterpret_cast<const byte *>(entry_str), buf_size);
-
-    entry_buf->pos(0);
-    nuraft::log_val_type tp = static_cast<nuraft::log_val_type>(entry_buf->get_byte());
-
-    ptr<buffer> data = buffer::copy(*entry_buf);
-    return cs_new<log_entry>(term, data, tp);
+    nuraft::log_val_type tp = static_cast<nuraft::log_val_type>(entry_str[0]);
+    auto data = buffer::alloc(buf_size - 1);
+    data->put_raw(reinterpret_cast<const byte *>(entry_str + 1), buf_size - 1);
+    data->pos(0);
+    return cs_new<log_entry>(0, data, tp); /// term is set latter
 }
 
 }

--- a/src/Service/LogEntry.h
+++ b/src/Service/LogEntry.h
@@ -38,7 +38,7 @@ class LogEntryBody
 {
 public:
     static ptr<buffer> serialize(ptr<log_entry> & entry);
-    static ptr<log_entry> parse(const char * entry_str, const UInt64 & term, size_t buf_size);
+    static ptr<log_entry> parse(const char * entry_str, size_t buf_size);
 };
 
 }

--- a/src/Service/NuRaftLogSegment.cpp
+++ b/src/Service/NuRaftLogSegment.cpp
@@ -572,7 +572,8 @@ int NuRaftLogSegment::loadLogEntry(int fd, off_t offset, LogEntryHeader * head, 
         return -1;
     }
 
-    entry = LogEntryBody::parse(entry_str, head->term, head->data_length);
+    entry = LogEntryBody::parse(entry_str, head->data_length);
+    entry->set_term(head->term);
 
     delete[] entry_str;
     return 0;


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #199 

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Avoid memory copy when parsing log