### PR TITLE
Forwarding error may cause request not found in request processor pending queue

### DIFF
--- a/src/Service/RequestProcessor.cpp
+++ b/src/Service/RequestProcessor.cpp
@@ -137,8 +137,8 @@ bool RequestProcessor::shouldProcessCommittedRequest(const RequestForSession & c
         found_in_pending_queue = false;
         LOG_WARNING(
             this->log,
-            "Not found committed(write) request {} in pending queue. Possible reason: 1.close requests from deadSessionCleanThread are not put "
-            "into pending queue; 2.error occurs(because of forward or append entries) but request is still committed, "
+            "Not found committed(write) request {} in pending queue. Possible reason: 1.close requests from deadSessionCleanThread are not "
+            "put into pending queue; 2.error occurs(because of forward or append entries) but request is still committed, "
             "'processErrorRequest' may delete request from pending request first, so here we can not find it.",
             committed_request.toSimpleString());
     };
@@ -349,10 +349,10 @@ void RequestProcessor::processErrorRequest(size_t count)
             {
                 LOG_WARNING(
                     this->log,
-                    "Not found error request {} in pending queue. Possible reason: 1.close requests from deadSessionCleanThread are not put "
-                    "into pending queue; 2.error occurs(forward or append entries) but request is still committed, "
-                    "'processCommittedRequest' may delete request from pending request first, so here we can not find it. We also delete "
-                    "it from errors.",
+                    "Not found error request {} in pending queue. Possible reason: 1. request forwarding error; 2.close requests from "
+                    "deadSessionCleanThread are not put into pending queue; 3.error occurs(forward or append entries) but request is still "
+                    "committed, 'processCommittedRequest' may delete request from pending request first, so here we can not find it. We "
+                    "also delete it from errors.",
                     error_request.toString());
 
                 error_request_ids.erase(error_request.getRequestId());


### PR DESCRIPTION
### Change log:
<!-- (Please describe the changes you have made in details. -->
- Forwarding error may cause request not found in request processor pending queue
```
2024.02.29 14:16:16.574302 [ 116 ] <Warning> RequestForwarder: Forward request ForwardType: User, session 0x4b8, xid 14265061 timeout
2024.02.29 14:16:16.574338 [ 116 ] <Warning> RequestProcessor: Found error request #0x4b8#14265061#Multi accepted:false error_code:-2
2024.02.29 14:16:16.574709 [ 59 ] <Warning> RequestProcessor: Not found error request #0x4b8#14265061#Multi accepted:false error_code:-2 in pending queue. Possible reason: 1.close requests from deadSessionCleanThread are not put into pending queue; 2.error occurs(forward or append entries) but request is still committed, 'processCommittedRequest' may delete request from pending request first, so here we can not find it. We also delete it from errors.
``

