### PR TITLE
Make snapshot load faster

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -47,10 +47,10 @@ jobs:
           submodules: recursive
 
       - name: Install tools
-        run: brew install ninja ccache
+        run: brew install ninja ccache cmake llvm@13
 
       - name: Generate Makefile
-        run: export CC=`which clang` CXX=`which clang++` && cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        run: export CC=$(brew --prefix llvm@13)/bin/clang CXX=$(brew --prefix llvm@13)/bin/clang++ && cmake -G Ninja -B ./build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/src/Service/KeeperStore.cpp
+++ b/src/Service/KeeperStore.cpp
@@ -1659,6 +1659,24 @@ void KeeperStore::buildPathChildren(bool from_zk_snapshot)
     }
 }
 
+void KeeperStore::buildBlockChildren(const std::vector<BlocksEdges> & all_objects_edges, UInt32 block_idx)
+{
+    for (auto & object_edges : all_objects_edges)
+    {
+        for (auto & [parent_path, path] : object_edges[block_idx])
+        {
+            auto parent = container.get(parent_path);
+
+            if (unlikely(parent == nullptr))
+            {
+                throw RK::Exception("Logical error: Build : can not find parent for node " + path, ErrorCodes::LOGICAL_ERROR);
+            }
+
+            parent->children.emplace(std::move(path));
+        }
+    }
+}
+
 void KeeperStore::cleanEphemeralNodes(int64_t session_id, ThreadSafeQueue<ResponseForSession> & responses_queue, bool ignore_response)
 {
     LOG_DEBUG(log, "Clean ephemeral nodes for session {}", toHexString(session_id));

--- a/src/Service/KeeperStore.cpp
+++ b/src/Service/KeeperStore.cpp
@@ -1635,9 +1635,9 @@ void KeeperStore::buildPathChildren(bool from_zk_snapshot)
 {
     LOG_INFO(log, "build path children in keeper storage {}", container.size());
     /// build children
-    for (UInt32 block_idx = 0; block_idx < container.getBlockNum(); block_idx++)
+    for (UInt32 bucket_idx = 0; bucket_idx < container.getBucketNum(); bucket_idx++)
     {
-        for (const auto & it : container.getMap(block_idx).getMap())
+        for (const auto & it : container.getMap(bucket_idx).getMap())
         {
             if (it.first == "/")
                 continue;
@@ -1659,11 +1659,11 @@ void KeeperStore::buildPathChildren(bool from_zk_snapshot)
     }
 }
 
-void KeeperStore::buildBlockChildren(const std::vector<BlocksEdges> & all_objects_edges, UInt32 block_idx)
+void KeeperStore::buildBucketChildren(const std::vector<BucketEdges> & all_objects_edges, UInt32 bucket_idx)
 {
     for (auto & object_edges : all_objects_edges)
     {
-        for (auto & [parent_path, path] : object_edges[block_idx])
+        for (auto & [parent_path, path] : object_edges[bucket_idx])
         {
             auto parent = container.get(parent_path);
 

--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -25,6 +25,8 @@ namespace RK
 struct StoreRequest;
 using StoreRequestPtr = std::shared_ptr<StoreRequest>;
 using ChildrenSet = std::unordered_set<String>;
+using Edge = std::pair<String, String>;
+using Edges = std::vector<Edge>;
 
 /**
  * Represent an entry in data tree.
@@ -160,6 +162,7 @@ public:
     bool erase(String const & key) { return mapFor(key).erase(key); }
 
     InnerMap & mapFor(String const & key) { return maps_[hash_(key) % NumBlocks]; }
+    UInt32 getBlockIndex(String const & key) { return hash_(key) % NumBlocks; }
     UInt32 getBlockNum() const { return NumBlocks; }
     InnerMap & getMap(const UInt32 & index) { return maps_[index]; }
 
@@ -200,6 +203,7 @@ public:
     using SessionIDs = std::vector<int64_t>;
 
     using Watches = std::unordered_map<String /* path, relative of root_path */, SessionIDs>;
+    using BlocksEdges = std::array<Edges, MAP_BLOCK_NUM>;
 
     /// global session id counter, used to allocate new session id.
     /// It should be same across all nodes.
@@ -296,6 +300,9 @@ public:
 
     /// Build path children after load data from snapshot
     void buildPathChildren(bool from_zk_snapshot = false);
+
+    // Build childrenset for the node in specified block after load data from snapshot.
+    void buildBlockChildren(const std::vector<BlocksEdges> & all_objects_edges, UInt32 block_idx);
 
     void finalize();
 

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -104,16 +104,16 @@ private:
     void getObjectPath(ulong object_id, String & path);
 
     /// Parse an snapshot object. We should take the version from snapshot in general.
-    void parseObject(KeeperStore & store, String obj_path, BlocksEdges &);
+    void parseObject(KeeperStore & store, String obj_path, BucketEdges &);
 
     /// Parse batch header in an object
     /// TODO use internal buffer
     void parseBatchHeader(ptr<std::fstream> fs, SnapshotBatchHeader & head);
 
     /// Parse a batch /// TODO delete
-    void parseBatchBody(KeeperStore & store, const String &, BlocksEdges &, SnapshotVersion version_);
+    void parseBatchBody(KeeperStore & store, const String &, BucketEdges &, SnapshotVersion version_);
     /// Parse a batch
-    void parseBatchBodyV2(KeeperStore & store, const String &, BlocksEdges &, SnapshotVersion version_);
+    void parseBatchBodyV2(KeeperStore & store, const String &, BucketEdges &, SnapshotVersion version_);
 
     /// Serialize whole data tree /// TODO delete
     size_t serializeDataTree(KeeperStore & storage);
@@ -168,7 +168,7 @@ private:
 
     std::map<ulong, String> objects_path;
 
-    std::vector<BlocksEdges> all_objects_edges;
+    std::vector<BucketEdges> all_objects_edges;
 
     /// Appended to snapshot file name
     String curr_time;

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -104,16 +104,16 @@ private:
     void getObjectPath(ulong object_id, String & path);
 
     /// Parse an snapshot object. We should take the version from snapshot in general.
-    void parseObject(KeeperStore & store, String obj_path);
+    void parseObject(KeeperStore & store, String obj_path, BlocksEdges &);
 
     /// Parse batch header in an object
     /// TODO use internal buffer
     void parseBatchHeader(ptr<std::fstream> fs, SnapshotBatchHeader & head);
 
     /// Parse a batch /// TODO delete
-    void parseBatchBody(KeeperStore & store, char * batch_buf, size_t length, SnapshotVersion version_);
+    void parseBatchBody(KeeperStore & store, const String &, BlocksEdges &, SnapshotVersion version_);
     /// Parse a batch
-    void parseBatchBodyV2(KeeperStore & store, char * buf, size_t length, SnapshotVersion version_);
+    void parseBatchBodyV2(KeeperStore & store, const String &, BlocksEdges &, SnapshotVersion version_);
 
     /// Serialize whole data tree /// TODO delete
     size_t serializeDataTree(KeeperStore & storage);
@@ -167,6 +167,8 @@ private:
     UInt64 last_log_term;
 
     std::map<ulong, String> objects_path;
+
+    std::vector<BlocksEdges> all_objects_edges;
 
     /// Appended to snapshot file name
     String curr_time;

--- a/src/Service/SnapshotCommon.cpp
+++ b/src/Service/SnapshotCommon.cpp
@@ -414,7 +414,7 @@ template void serializeMap<StringMap>(StringMap & snap_map, UInt32 save_batch_si
 template void serializeMap<IntMap>(IntMap & snap_map, UInt32 save_batch_size, SnapshotVersion version, String & path);
 
 
-void parseBatchData(KeeperStore & store, const SnapshotBatchPB & batch, BlocksEdges & blocks_edges, SnapshotVersion version)
+void parseBatchData(KeeperStore & store, const SnapshotBatchPB & batch, BucketEdges & buckets_edges, SnapshotVersion version)
 {
     for (int i = 0; i < batch.data_size(); i++)
     {
@@ -464,11 +464,11 @@ void parseBatchData(KeeperStore & store, const SnapshotBatchPB & batch, BlocksEd
             throw Exception(ErrorCodes::CORRUPTED_SNAPSHOT, "Can't find parent path for path {}", path);
 
         auto parent_path = rslash_pos == 0 ? "/" : path.substr(0, rslash_pos);
-        auto idx = store.container.getBlockIndex(parent_path);
+        auto idx = store.container.getBucketIndex(parent_path);
 
-        //  Storage edges in different bucket, according to the block index of parent node.
+        //  Storage edges in different bucket, according to the bucket index of parent node.
         //  Which allow us to insert child paths for all nodes in parallel.
-        blocks_edges[idx].emplace_back(std::move(parent_path), path.substr(rslash_pos + 1));
+        buckets_edges[idx].emplace_back(std::move(parent_path), path.substr(rslash_pos + 1));
     }
 }
 
@@ -861,7 +861,7 @@ ptr<SnapshotBatchBody> SnapshotBatchBody::parse(const String & data)
     return batch_body;
 }
 
-void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BlocksEdges & blocks_edges, SnapshotVersion version)
+void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BucketEdges & buckets_edges, SnapshotVersion version)
 {
     for (size_t i = 0; i < batch.size(); i++)
     {
@@ -910,11 +910,11 @@ void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BlocksEdge
             throw Exception(ErrorCodes::CORRUPTED_SNAPSHOT, "Can't find parent path for path {}", path);
 
         auto parent_path = rslash_pos == 0 ? "/" : path.substr(0, rslash_pos);
-        auto idx = store.container.getBlockIndex(parent_path);
+        auto idx = store.container.getBucketIndex(parent_path);
 
-        //  Storage edges in different bucket, according to the block index of parent node.
+        //  Storage edges in different bucket, according to the bucket index of parent node.
         //  Which allow us to insert child paths for all nodes in parallel.
-        blocks_edges[idx].emplace_back(std::move(parent_path), path.substr(rslash_pos + 1));
+        buckets_edges[idx].emplace_back(std::move(parent_path), path.substr(rslash_pos + 1));
 
     }
 }

--- a/src/Service/SnapshotCommon.h
+++ b/src/Service/SnapshotCommon.h
@@ -34,6 +34,7 @@ static constexpr UInt32 SAVE_BATCH_SIZE = 10000;
 
 using StringMap = std::unordered_map<String, String>;
 using IntMap = std::unordered_map<String, int64_t>;
+using BlocksEdges = KeeperStore::BlocksEdges;
 
 enum SnapshotVersion : uint8_t
 {
@@ -127,7 +128,7 @@ template <typename T>
 void serializeMap(T & snap_map, UInt32 save_batch_size, SnapshotVersion version, String & path);
 
 /// Parse snapshot batch without protobuf
-void parseBatchData(KeeperStore & store, const SnapshotBatchPB & batch, SnapshotVersion version);
+void parseBatchData(KeeperStore & store, const SnapshotBatchPB & batch, BlocksEdges & blocks_edges, SnapshotVersion version);
 void parseBatchSession(KeeperStore & store, const SnapshotBatchPB & batch, SnapshotVersion version);
 void parseBatchAclMap(KeeperStore & store, const SnapshotBatchPB & batch, SnapshotVersion version);
 void parseBatchIntMap(KeeperStore & store, const SnapshotBatchPB & batch, SnapshotVersion version);
@@ -152,7 +153,7 @@ template <typename T>
 void serializeMapV2(T & snap_map, UInt32 save_batch_size, SnapshotVersion version, String & path);
 
 /// parse snapshot batch
-void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);
+void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BlocksEdges & blocks_edges, SnapshotVersion version);
 void parseBatchSessionV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);
 void parseBatchAclMapV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);
 void parseBatchIntMapV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);

--- a/src/Service/SnapshotCommon.h
+++ b/src/Service/SnapshotCommon.h
@@ -34,7 +34,7 @@ static constexpr UInt32 SAVE_BATCH_SIZE = 10000;
 
 using StringMap = std::unordered_map<String, String>;
 using IntMap = std::unordered_map<String, int64_t>;
-using BlocksEdges = KeeperStore::BlocksEdges;
+using BucketEdges = KeeperStore::BucketEdges;
 
 enum SnapshotVersion : uint8_t
 {
@@ -128,7 +128,7 @@ template <typename T>
 void serializeMap(T & snap_map, UInt32 save_batch_size, SnapshotVersion version, String & path);
 
 /// Parse snapshot batch without protobuf
-void parseBatchData(KeeperStore & store, const SnapshotBatchPB & batch, BlocksEdges & blocks_edges, SnapshotVersion version);
+void parseBatchData(KeeperStore & store, const SnapshotBatchPB & batch, BucketEdges & buckets_edges, SnapshotVersion version);
 void parseBatchSession(KeeperStore & store, const SnapshotBatchPB & batch, SnapshotVersion version);
 void parseBatchAclMap(KeeperStore & store, const SnapshotBatchPB & batch, SnapshotVersion version);
 void parseBatchIntMap(KeeperStore & store, const SnapshotBatchPB & batch, SnapshotVersion version);
@@ -153,7 +153,7 @@ template <typename T>
 void serializeMapV2(T & snap_map, UInt32 save_batch_size, SnapshotVersion version, String & path);
 
 /// parse snapshot batch
-void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BlocksEdges & blocks_edges, SnapshotVersion version);
+void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BucketEdges & buckets_edges, SnapshotVersion version);
 void parseBatchSessionV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);
 void parseBatchAclMapV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);
 void parseBatchIntMapV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);

--- a/src/Service/tests/gtest_raft_snapshot.cpp
+++ b/src/Service/tests/gtest_raft_snapshot.cpp
@@ -244,7 +244,7 @@ void assertStateMachineEquals(KeeperStore & storage, KeeperStore & ano_storage)
 
 
     /// assert container
-    for (uint32_t i = 0; i < KeeperStore::MAP_BLOCK_NUM; i++)
+    for (uint32_t i = 0; i < KeeperStore::MAP_BUCKET_NUM; i++)
     {
         auto & map = storage.container.getMap(i);
         auto & ano_map = ano_storage.container.getMap(i);
@@ -434,7 +434,7 @@ TEST(RaftSnapshot, readAndSaveSnapshot)
 void compareKeeperStore(KeeperStore & store, KeeperStore & new_store, bool compare_acl)
 {
     ASSERT_EQ(new_store.container.size(), store.container.size());
-    for (UInt32 i = 0; i < store.container.getBlockNum(); i++)
+    for (UInt32 i = 0; i < store.container.getBucketNum(); i++)
     {
         auto & inner_map = store.container.getMap(i);
         for (auto it = inner_map.getMap().begin(); it != inner_map.getMap().end(); it++)


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #221
For nodes count 58680021, snapshot size 12GB

|                     | Before(sec) | After(sec) |
| ------------------- | ----------- | ---------- |
| Parse from disk     | 90          | 70         |
| Build children path | 90          | 9          |
### Change log:
<!-- (Please describe the changes you have made in details. -->

Optimizations:

1. Reduced one buffer copy and destruction.
2. Storage edges in bucketed based on the parent node's bucket number, and built childrenSet in parallel.
3. Reserved space for childrenSet in advance.
