### PR TITLE
Add more metrics for mntr command

### DIFF
--- a/docs/how-to-monitor-and-manage.md
+++ b/docs/how-to-monitor-and-manage.md
@@ -57,39 +57,39 @@ zk_open_file_descriptor_count	126
 zk_max_file_descriptor_count	60480000
 zk_followers	2
 zk_synced_followers	2
-zk_p50_apply_read_request_time_ms	0.000000
-zk_p90_apply_read_request_time_ms	0.000000
-zk_p99_apply_read_request_time_ms	0.000000
-zk_p999_apply_read_request_time_ms	0.000000
+zk_p50_apply_read_request_time_ms	0.0
+zk_p90_apply_read_request_time_ms	0.0
+zk_p99_apply_read_request_time_ms	0.0
+zk_p999_apply_read_request_time_ms	0.0
 zk_cnt_apply_read_request_time_ms	151225987
 zk_sum_apply_read_request_time_ms	19
-zk_p50_apply_write_request_time_ms	0.000000
-zk_p90_apply_write_request_time_ms	0.000000
-zk_p99_apply_write_request_time_ms	0.000000
-zk_p999_apply_write_request_time_ms	0.000000
+zk_p50_apply_write_request_time_ms	0.0
+zk_p90_apply_write_request_time_ms	0.0
+zk_p99_apply_write_request_time_ms	0.0
+zk_p999_apply_write_request_time_ms	0.0
 zk_cnt_apply_write_request_time_ms	151225987
 zk_sum_apply_write_request_time_ms	856
-zk_avg_batch_size	119.000000
-zk_min_batch_size	1.000000
-zk_max_batch_size	200
-zk_cnt_batch_size	383096
-zk_sum_batch_size	45654000
-zk_p50_push_request_queue_time_ms	0.000000
-zk_p90_push_request_queue_time_ms	0.000000
-zk_p99_push_request_queue_time_ms	0.000000
-zk_p999_push_request_queue_time_ms	0.000000
+zk_avg_log_replication_batch_size	119.0
+zk_min_log_replication_batch_size	1.0
+zk_max_log_replication_batch_size	200
+zk_cnt_log_replication_batch_size	383096
+zk_sum_log_replication_batch_size	45654000
+zk_p50_push_request_queue_time_ms	0.0
+zk_p90_push_request_queue_time_ms	0.0
+zk_p99_push_request_queue_time_ms	0.0
+zk_p999_push_request_queue_time_ms	0.0
 zk_cnt_push_request_queue_time_ms	25595940
 zk_sum_push_request_queue_time_ms	76
-zk_p50_readlatency	0.000000
-zk_p90_readlatency	1.000000
-zk_p99_readlatency	1.000000
-zk_p999_readlatency	1.000000
+zk_p50_readlatency	0.0
+zk_p90_readlatency	1.0
+zk_p99_readlatency	1.0
+zk_p999_readlatency	1.0
 zk_cnt_readlatency	10237988
 zk_sum_readlatency	1992231
-zk_p50_updatelatency	3.000000
-zk_p90_updatelatency	3.000000
-zk_p99_updatelatency	4.000000
-zk_p999_updatelatency	5.903000
+zk_p50_updatelatency	3.0
+zk_p90_updatelatency	3.0
+zk_p99_updatelatency	4.0
+zk_p999_updatelatency	5.9
 zk_cnt_updatelatency	15357952
 zk_sum_updatelatency	39688173
 ```
@@ -116,12 +116,12 @@ zk_open_file_descriptor_count: current opening fd count
 zk_max_file_descriptor_count: max opening fd count
 zk_followers: follower count, only present on the leader
 zk_synced_followers: synced follower count, only present on the leader
-apply_read_request_time_ms: The time for request processor to process read request
-apply_write_request_time_ms: The time for request processor to process write request
-batch_size: Records the batch size of each batch accumulation for replication
-push_request_queue_time_ms: The time for push request from handler to dispatcher's request queue
-readlatency: Latency for read request. The timing start from when the server see the request until it leave final request processor
-updatelatency: Latency for write request. The timing start from when the server see the request until it leave final request processor
+zk_apply_read_request_time_ms: The time only for request processor to process read requests
+zk_apply_write_request_time_ms: The time only for request processor to process write requests, replication is not included for write requests
+zk_log_replication_batch_size: Records the batch size of each batch accumulation for replication
+zk_push_request_queue_time_ms: The time for push request from handler to dispatcher's request queue
+zk_readlatency: Latency for read request. The time start from when the server see the request until it leave final request processor
+zk_updatelatency: Latency for write request. The time start from when the server see the request until it leave final request processor
 ```
 Please note that the metrics `zk_followers` and `zk_synced_followers` are only present on the leader.
 

--- a/docs/how-to-monitor-and-manage.md
+++ b/docs/how-to-monitor-and-manage.md
@@ -36,28 +36,62 @@ Process uptime in seconds.
 `mntr` provide rich metrics and is the main monitoring command. The following is the output
 
 ```
-zk_version	RaftKeeper v2.0.4-e80e94979318adc94e81664053d782d0c9d7e60f, built on 2024-01-11 10:59:45 CST
+zk_version	RaftKeeper v2.0.5-96935adae174aaa430db0af14f823b0bf892f38e, built on 2024-04-15 17:19:43 CST
 zk_compatible_mode	zookeeper
 zk_avg_latency	1
-zk_max_latency	14598
+zk_max_latency	546
 zk_min_latency	0
-zk_packets_received	59695194
-zk_packets_sent	60406965
+zk_packets_received	25596328
+zk_packets_sent	25595940
 zk_num_alive_connections	0
 zk_outstanding_requests	0
 zk_server_state	leader
-zk_is_leader 1
-zk_znode_count	2899570
+zk_znode_count	2
 zk_watch_count	0
-zk_ephemerals_count	41933
-zk_approximate_data_size	1179161410
-zk_snap_count	619
-zk_snap_time_ms	9058483
+zk_ephemerals_count	0
+zk_approximate_data_size	3757
+zk_snap_count	2
+zk_snap_time_ms	1039
 zk_in_snapshot	0
 zk_open_file_descriptor_count	126
 zk_max_file_descriptor_count	60480000
 zk_followers	2
 zk_synced_followers	2
+zk_p50_apply_read_request_time_ms	0.000000
+zk_p90_apply_read_request_time_ms	0.000000
+zk_p99_apply_read_request_time_ms	0.000000
+zk_p999_apply_read_request_time_ms	0.000000
+zk_cnt_apply_read_request_time_ms	151225987
+zk_sum_apply_read_request_time_ms	19
+zk_p50_apply_write_request_time_ms	0.000000
+zk_p90_apply_write_request_time_ms	0.000000
+zk_p99_apply_write_request_time_ms	0.000000
+zk_p999_apply_write_request_time_ms	0.000000
+zk_cnt_apply_write_request_time_ms	151225987
+zk_sum_apply_write_request_time_ms	856
+zk_avg_batch_size	119.000000
+zk_min_batch_size	1.000000
+zk_max_batch_size	200
+zk_cnt_batch_size	383096
+zk_sum_batch_size	45654000
+zk_p50_push_request_queue_time_ms	0.000000
+zk_p90_push_request_queue_time_ms	0.000000
+zk_p99_push_request_queue_time_ms	0.000000
+zk_p999_push_request_queue_time_ms	0.000000
+zk_cnt_push_request_queue_time_ms	25595940
+zk_sum_push_request_queue_time_ms	76
+zk_p50_readlatency	0.000000
+zk_p90_readlatency	1.000000
+zk_p99_readlatency	1.000000
+zk_p999_readlatency	1.000000
+zk_cnt_readlatency	10237988
+zk_sum_readlatency	1992231
+zk_p50_updatelatency	3.000000
+zk_p90_updatelatency	3.000000
+zk_p99_updatelatency	4.000000
+zk_p999_updatelatency	5.903000
+zk_cnt_updatelatency	15357952
+zk_sum_updatelatency	39688173
 ```
 The explanation of the metrics is as follows:
 ```
@@ -82,6 +116,12 @@ zk_open_file_descriptor_count: current opening fd count
 zk_max_file_descriptor_count: max opening fd count
 zk_followers: follower count, only present on the leader
 zk_synced_followers: synced follower count, only present on the leader
+apply_read_request_time_ms: The time for request processor to process read request
+apply_write_request_time_ms: The time for request processor to process write request
+batch_size: Records the batch size of each batch accumulation for replication
+push_request_queue_time_ms: The time for push request from handler to dispatcher's request queue
+readlatency: Latency for read request. The timing start from when the server see the request until it leave final request processor
+updatelatency: Latency for write request. The timing start from when the server see the request until it leave final request processor
 ```
 Please note that the metrics `zk_followers` and `zk_synced_followers` are only present on the leader.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,9 +66,7 @@ if ((NOT USE_LIBCXX) AND COMPILER_CLANG AND OS_LINUX)
 endif()
 
 set(dbms_headers)
-set(dbms_sources
-        Service/Metrics.cpp
-        Service/Metrics.h)
+set(dbms_sources)
 set (all_modules)
 
 macro(add_object_library name common_path)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,9 @@ if ((NOT USE_LIBCXX) AND COMPILER_CLANG AND OS_LINUX)
 endif()
 
 set(dbms_headers)
-set(dbms_sources)
+set(dbms_sources
+        Service/Metrics.cpp
+        Service/Metrics.h)
 set (all_modules)
 
 macro(add_object_library name common_path)

--- a/src/Service/FourLetterCommand.cpp
+++ b/src/Service/FourLetterCommand.cpp
@@ -12,6 +12,7 @@
 #include <Common/config_version.h>
 #include <Common/getCurrentProcessFDCount.h>
 #include <Common/getMaxFileDescriptorCount.h>
+#include <Service/Metrics.h>
 
 #include <unistd.h>
 
@@ -272,12 +273,22 @@ String MonitorCommand::run()
         print(ret, "synced_followers", keeper_info.synced_follower_count);
     }
 
+    for (auto && [_, values] : Metrics::getMetrics().dumpMetricsValues())
+    {
+        for (auto && line : values)
+        {
+            writeText(line, ret);
+            writeText("\n", ret);
+        }
+    }
+
     return ret.str();
 }
 
 String StatResetCommand::run()
 {
     keeper_dispatcher.resetConnectionStats();
+    Metrics::getMetrics().reset();
     return "Server stats reset.\n";
 }
 

--- a/src/Service/KeeperDispatcher.cpp
+++ b/src/Service/KeeperDispatcher.cpp
@@ -200,7 +200,7 @@ bool KeeperDispatcher::pushRequest(const Coordination::ZooKeeperRequestPtr & req
     }
     else if (!requests_queue->tryPush(std::move(request_info), configuration_and_settings->raft_settings->operation_timeout_ms))
         throw Exception("Cannot push request to queue within operation timeout", ErrorCodes::TIMEOUT_EXCEEDED);
-    Metrics::getMetrics().PUSH_REQUESTS_QUEUE_TIME->add(watch.elapsedMilliseconds());
+    Metrics::getMetrics().push_request_queue_time_ms->add(watch.elapsedMilliseconds());
     return true;
 }
 

--- a/src/Service/KeeperDispatcher.h
+++ b/src/Service/KeeperDispatcher.h
@@ -208,6 +208,13 @@ public:
         keeper_stats.reset();
     }
 
+    void incrementPushRequest()
+    {
+        std::lock_guard lock(keeper_stats_mutex);
+        keeper_stats.incrementPacketsReceived();
+    }
+
+
     uint64_t createSnapshot() { return server->createSnapshot(); }
 
     KeeperLogInfo getKeeperLogInfo() { return server->getKeeperLogInfo(); }

--- a/src/Service/Metrics.cpp
+++ b/src/Service/Metrics.cpp
@@ -1,4 +1,4 @@
-#include "Metrics.h"
+#include <Service/Metrics.h>
 #include <algorithm>
 
 namespace RK
@@ -71,12 +71,12 @@ Strings AdvanceSummary::values() const
     std::sort(numbers.begin(), numbers.end());
 
     Strings results;
-    results.emplace_back("zk_p50_" + name + '\t' + std::to_string(getValue(numbers, 0.5)));
-    results.emplace_back("zk_p90_" + name + '\t' + std::to_string(getValue(numbers, 0.9)));
-    results.emplace_back("zk_p99_" + name + '\t' + std::to_string(getValue(numbers, 0.99)));
-    results.emplace_back("zk_p999_" + name + '\t' + std::to_string(getValue(numbers, 0.999)));
-    results.emplace_back("zk_cnt_" + name + '\t' + std::to_string(count.load()));
-    results.emplace_back("zk_sum_" + name + '\t' + std::to_string(sum.load()));
+    results.emplace_back(fmt::format("zk_p50_{}\t{:.1f}", name, getValue(numbers, 0.5)));
+    results.emplace_back(fmt::format("zk_p90_{}\t{:.1f}", name, getValue(numbers, 0.9)));
+    results.emplace_back(fmt::format("zk_p99_{}\t{:.1f}", name, getValue(numbers, 0.99)));
+    results.emplace_back(fmt::format("zk_p999_{}\t{:.1f}", name, getValue(numbers, 0.999)));
+    results.emplace_back(fmt::format("zk_cnt_{}\t{}", name, count.load()));
+    results.emplace_back(fmt::format("zk_sum_{}\t{}", name, sum.load()));
     return results;
 }
 
@@ -99,13 +99,11 @@ void BasicSummary::add(RK::UInt64 value)
 Strings BasicSummary::values() const
 {
     Strings results;
-
-    results.emplace_back("zk_avg_" + name + '\t' + std::to_string(getAvg()));
-    results.emplace_back("zk_min_" + name + '\t' + std::to_string(getMin()));
-    results.emplace_back("zk_max_" + name + '\t' + std::to_string(max.load()));
-    results.emplace_back("zk_cnt_" + name + '\t' + std::to_string(count.load()));
-    results.emplace_back("zk_sum_" + name + '\t' + std::to_string(sum.load()));
-
+    results.emplace_back(fmt::format("zk_avg_{}\t{:.1f}", name, getAvg()));
+    results.emplace_back(fmt::format("zk_min_{}\t{}", name, getMin()));
+    results.emplace_back(fmt::format("zk_max_{}\t{}", name, max.load()));
+    results.emplace_back(fmt::format("zk_cnt_{}\t{}", name, count.load()));
+    results.emplace_back(fmt::format("zk_sum_{}\t{}", name, sum.load()));
     return results;
 }
 
@@ -114,7 +112,7 @@ using SummaryPtr = std::shared_ptr<Summary>;
 Metrics::Metrics()
 {
     PUSH_REQUESTS_QUEUE_TIME = getSummary("push_request_queue_time_ms", SummaryLevel::ADVANCED);
-    BATCH_SIZE = getSummary("batch_size", SummaryLevel::BASIC);
+    LOG_REPLICATION_BATCH_SIZE = getSummary("log_replication_batch_size", SummaryLevel::BASIC);
     APPLY_WRITE_REQUEST = getSummary("apply_write_request_time_ms", SummaryLevel::ADVANCED);
     APPLY_READ_REQUEST = getSummary("apply_read_request_time_ms", SummaryLevel::ADVANCED);
     READ_LATENCY = getSummary("readlatency", SummaryLevel::ADVANCED);

--- a/src/Service/Metrics.cpp
+++ b/src/Service/Metrics.cpp
@@ -1,0 +1,153 @@
+#include "Metrics.h"
+#include <algorithm>
+
+namespace RK
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+void ReservoirSampler::update(RK::UInt64 value)
+{
+    UInt64 c = count.fetch_add(1);
+
+    if (c < DEFAULT_SIZE)
+    {
+        values[c].store(value);
+        return;
+    }
+
+    static thread_local std::mt19937 gen{std::random_device{}()};
+    std::uniform_int_distribution<> dis(0, c);
+
+    UInt64 i = dis(gen);
+    if (i < DEFAULT_SIZE)
+        values[i].store(value);
+}
+
+std::vector<UInt64> ReservoirSampler::getSnapshot() const
+{
+    size_t s = std::min(DEFAULT_SIZE, count.load());
+
+    std::vector<UInt64> copy(s);
+
+    for (size_t i = 0; i < s; i++)
+        copy[i] = values[i].load();
+
+    return copy;
+}
+
+double AdvanceSummary::getValue(const std::vector<UInt64>& numbers, double quantile)
+{
+    if (quantile < 0.0 || quantile > 1.0)
+    {
+        LOG_ERROR(&Poco::Logger::get("AdvanceSummary"), "Quantile {} is not in [0..1]", quantile);
+        return 0.0;
+    }
+
+    if (numbers.size() == 0)
+        return 0.0;
+
+    auto index = quantile * (numbers.size() + 1);
+    size_t pos = static_cast<size_t>(index);
+
+    if (pos < 1)
+        return numbers[0];
+
+
+    if (pos >= numbers.size())
+        return numbers.back();
+
+    auto lower = numbers[pos - 1];
+    auto upper = numbers[pos];
+    return lower + (index - std::floor(index)) * (upper - lower);
+}
+
+Strings AdvanceSummary::values() const
+{
+    auto numbers = reservoir_sampler.getSnapshot();
+    std::sort(numbers.begin(), numbers.end());
+
+    Strings results;
+    results.emplace_back("zk_p50_" + name + '\t' + std::to_string(getValue(numbers, 0.5)));
+    results.emplace_back("zk_p90_" + name + '\t' + std::to_string(getValue(numbers, 0.9)));
+    results.emplace_back("zk_p99_" + name + '\t' + std::to_string(getValue(numbers, 0.99)));
+    results.emplace_back("zk_p999_" + name + '\t' + std::to_string(getValue(numbers, 0.999)));
+    results.emplace_back("zk_cnt_" + name + '\t' + std::to_string(count.load()));
+    results.emplace_back("zk_sum_" + name + '\t' + std::to_string(sum.load()));
+    return results;
+}
+
+void BasicSummary::add(RK::UInt64 value)
+{
+    UInt64 current;
+
+    while (value > (current = max.load()) && !max.compare_exchange_strong(current, value))
+    {
+    }
+
+    while (value < (current = min.load()) && !min.compare_exchange_strong(current, value))
+    {
+    }
+
+    count ++;
+    sum += value;
+}
+
+Strings BasicSummary::values() const
+{
+    Strings results;
+
+    results.emplace_back("zk_avg_" + name + '\t' + std::to_string(getAvg()));
+    results.emplace_back("zk_min_" + name + '\t' + std::to_string(getMin()));
+    results.emplace_back("zk_max_" + name + '\t' + std::to_string(max.load()));
+    results.emplace_back("zk_cnt_" + name + '\t' + std::to_string(count.load()));
+    results.emplace_back("zk_sum_" + name + '\t' + std::to_string(sum.load()));
+
+    return results;
+}
+
+using SummaryPtr = std::shared_ptr<Summary>;
+
+Metrics::Metrics()
+{
+    PUSH_REQUESTS_QUEUE_TIME = getSummary("push_request_queue_time_ms", SummaryLevel::ADVANCED);
+    BATCH_SIZE = getSummary("batch_size", SummaryLevel::BASIC);
+    APPLY_WRITE_REQUEST = getSummary("apply_write_request_time_ms", SummaryLevel::ADVANCED);
+    APPLY_READ_REQUEST = getSummary("apply_read_request_time_ms", SummaryLevel::ADVANCED);
+    READ_LATENCY = getSummary("readlatency", SummaryLevel::ADVANCED);
+    UPDATE_LATENCY = getSummary("updatelatency", SummaryLevel::ADVANCED);
+}
+
+SummaryPtr Metrics::getSummary(const RK::String & name, RK::SummaryLevel detailLevel)
+{
+    SummaryPtr summary;
+
+    if (summaries.contains(name))
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "Already registered summary {} ", name);
+
+    if (detailLevel == SummaryLevel::BASIC)
+        summary = std::make_shared<BasicSummary>(name);
+    else
+        summary =  std::make_shared<AdvanceSummary>(name);
+
+    summaries.emplace(name, summary);
+
+    return summary;
+}
+
+std::map<String, Strings> Metrics::dumpMetricsValues() const
+{
+    std::map<String, Strings> metrics_values;
+    for (const auto & [name, summary] : summaries)
+    {
+        metrics_values.emplace(name, summary->values());
+    }
+
+    return metrics_values;
+}
+
+}

--- a/src/Service/Metrics.cpp
+++ b/src/Service/Metrics.cpp
@@ -47,7 +47,7 @@ double AdvanceSummary::getValue(const std::vector<UInt64>& numbers, double quant
         return 0.0;
     }
 
-    if (numbers.size() == 0)
+    if (numbers.empty())
         return 0.0;
 
     auto index = quantile * (numbers.size() + 1);
@@ -111,12 +111,12 @@ using SummaryPtr = std::shared_ptr<Summary>;
 
 Metrics::Metrics()
 {
-    PUSH_REQUESTS_QUEUE_TIME = getSummary("push_request_queue_time_ms", SummaryLevel::ADVANCED);
-    LOG_REPLICATION_BATCH_SIZE = getSummary("log_replication_batch_size", SummaryLevel::BASIC);
-    APPLY_WRITE_REQUEST = getSummary("apply_write_request_time_ms", SummaryLevel::ADVANCED);
-    APPLY_READ_REQUEST = getSummary("apply_read_request_time_ms", SummaryLevel::ADVANCED);
-    READ_LATENCY = getSummary("readlatency", SummaryLevel::ADVANCED);
-    UPDATE_LATENCY = getSummary("updatelatency", SummaryLevel::ADVANCED);
+    push_request_queue_time_ms = getSummary("push_request_queue_time_ms", SummaryLevel::ADVANCED);
+    log_replication_batch_size = getSummary("log_replication_batch_size", SummaryLevel::BASIC);
+    apply_write_request_time_ms = getSummary("apply_write_request_time_ms", SummaryLevel::ADVANCED);
+    apply_read_request_time_ms = getSummary("apply_read_request_time_ms", SummaryLevel::ADVANCED);
+    read_latency = getSummary("readlatency", SummaryLevel::ADVANCED);
+    update_latency = getSummary("updatelatency", SummaryLevel::ADVANCED);
 }
 
 SummaryPtr Metrics::getSummary(const RK::String & name, RK::SummaryLevel detailLevel)

--- a/src/Service/Metrics.h
+++ b/src/Service/Metrics.h
@@ -132,7 +132,7 @@ public:
         return current_count > 0 ? current_sum / current_count : 0;
     }
 
-    double getMin() const
+    UInt64 getMin() const
     {
         UInt64 current_min = min.load();
         return current_min == std::numeric_limits<UInt64>::max() ? 0 : current_min;
@@ -171,7 +171,7 @@ public:
     }
 
     SummaryPtr PUSH_REQUESTS_QUEUE_TIME;
-    SummaryPtr BATCH_SIZE;
+    SummaryPtr LOG_REPLICATION_BATCH_SIZE;
     SummaryPtr APPLY_READ_REQUEST;
     SummaryPtr APPLY_WRITE_REQUEST;
     SummaryPtr READ_LATENCY;

--- a/src/Service/Metrics.h
+++ b/src/Service/Metrics.h
@@ -170,12 +170,12 @@ public:
             summary->reset();
     }
 
-    SummaryPtr PUSH_REQUESTS_QUEUE_TIME;
-    SummaryPtr LOG_REPLICATION_BATCH_SIZE;
-    SummaryPtr APPLY_READ_REQUEST;
-    SummaryPtr APPLY_WRITE_REQUEST;
-    SummaryPtr READ_LATENCY;
-    SummaryPtr UPDATE_LATENCY;
+    SummaryPtr push_request_queue_time_ms;
+    SummaryPtr log_replication_batch_size;
+    SummaryPtr apply_write_request_time_ms;
+    SummaryPtr apply_read_request_time_ms;
+    SummaryPtr read_latency;
+    SummaryPtr update_latency;
 
 private:
     Metrics();

--- a/src/Service/Metrics.h
+++ b/src/Service/Metrics.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <common/types.h>
+#include <array>
+#include <atomic>
+#include <random>
+#include <Poco/Logger.h>
+#include <common/logger_useful.h>
+#include <unordered_map>
+#include <map>
+#include <Common/Exception.h>
+
+
+namespace RK
+{
+
+inline UInt64 getCurrentTimeMilliseconds()
+{
+    return duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+};
+
+
+/**
+ * Uses the reservoir sampling algorithm to sample statistical values
+ * The ReservoirSampler is thread-safe
+ */
+class ReservoirSampler
+{
+public:
+    static constexpr UInt64 DEFAULT_SIZE = 4096;
+
+    size_t size() const
+    {
+        UInt64 c = count.load();
+        return c > DEFAULT_SIZE ? c : DEFAULT_SIZE;
+    }
+
+    void update(UInt64 value);
+
+    void reset()
+    {
+        count.store(0);
+    }
+
+    std::vector<UInt64> getSnapshot() const;
+
+private:
+    std::atomic<UInt64> count{0};
+    std::array<std::atomic<UInt64>, DEFAULT_SIZE> values;
+};
+
+
+class Summary
+{
+public:
+    virtual void add(UInt64) = 0;
+    virtual void reset() = 0;
+    virtual ~Summary() = default;
+    virtual Strings values() const = 0;
+};
+
+enum SummaryLevel
+{
+    /**
+         * The returned Summary is expected to track only simple aggregated
+         * values, like min/max/avg
+         */
+    BASIC,
+    /**
+         * It is expected that the returned Summary performs expensive
+         * aggregations, like percentiles.
+         */
+    ADVANCED
+};
+
+
+class AdvanceSummary : public Summary
+{
+public:
+    AdvanceSummary(const String & name_): name(name_)
+    {
+    }
+
+    void reset() override
+    {
+        count.store(0);
+        sum.store(0);
+        reservoir_sampler.reset();
+    }
+
+    void add(UInt64 value) override
+    {
+        count ++;
+        sum += value;
+        reservoir_sampler.update(value);
+    }
+
+    static double getValue(const std::vector<UInt64>& numbers, double quantile);
+
+    Strings values() const override;
+
+private:
+    String name;
+    ReservoirSampler reservoir_sampler;
+    std::atomic<UInt64> count{0};
+    std::atomic<UInt64> sum{0};
+};
+
+
+class BasicSummary : public Summary
+{
+public:
+    BasicSummary(const String & name_): name(name_)
+    {
+    }
+
+    void reset() override
+    {
+        count.store(0);
+        sum.store(0);
+        min.store(std::numeric_limits<UInt64>::max());
+        max.store(0);
+    }
+
+    void add(UInt64 value) override;
+
+    double getAvg() const
+    {
+        UInt64 current_count = count.load();
+        UInt64 current_sum = sum.load();
+
+        return current_count > 0 ? current_sum / current_count : 0;
+    }
+
+    double getMin() const
+    {
+        UInt64 current_min = min.load();
+        return current_min == std::numeric_limits<UInt64>::max() ? 0 : current_min;
+    }
+
+    Strings values() const override;
+
+private:
+    String name;
+    std::atomic<UInt64> count{0};
+    std::atomic<UInt64> sum{0};
+    std::atomic<UInt64> min{std::numeric_limits<UInt64>::max()};
+    std::atomic<UInt64> max{0};
+};
+
+/** Implements Summary Metrics for RK.
+  * There is possible race-condition, but we don't need the stats to be extremely accurate.
+  */
+class Metrics
+{
+public:
+    using SummaryPtr = std::shared_ptr<Summary>;
+
+    static Metrics& getMetrics()
+    {
+        static Metrics metrics;
+        return metrics;
+    }
+
+    std::map<String, Strings> dumpMetricsValues() const;
+
+    void reset()
+    {
+        for (const auto & [_, summary] : summaries)
+            summary->reset();
+    }
+
+    SummaryPtr PUSH_REQUESTS_QUEUE_TIME;
+    SummaryPtr BATCH_SIZE;
+    SummaryPtr APPLY_READ_REQUEST;
+    SummaryPtr APPLY_WRITE_REQUEST;
+    SummaryPtr READ_LATENCY;
+    SummaryPtr UPDATE_LATENCY;
+
+private:
+    Metrics();
+    SummaryPtr getSummary(const String & name, SummaryLevel detailLevel);
+
+    std::map<String, SummaryPtr> summaries;
+};
+
+}

--- a/src/Service/RequestAccumulator.cpp
+++ b/src/Service/RequestAccumulator.cpp
@@ -35,7 +35,7 @@ void RequestAccumulator::run()
         {
             if (!requests_queue->tryPop(request_for_session))
             {
-                Metrics::getMetrics().LOG_REPLICATION_BATCH_SIZE->add(to_append_batch.size());
+                Metrics::getMetrics().log_replication_batch_size->add(to_append_batch.size());
                 result = server->pushRequestBatch(to_append_batch);
                 waitResultAndHandleError(result, to_append_batch);
                 result.reset();
@@ -51,7 +51,7 @@ void RequestAccumulator::run()
 
             if (to_append_batch.size() >= max_batch_size)
             {
-                Metrics::getMetrics().LOG_REPLICATION_BATCH_SIZE->add(to_append_batch.size());
+                Metrics::getMetrics().log_replication_batch_size->add(to_append_batch.size());
                 result = server->pushRequestBatch(to_append_batch);
                 waitResultAndHandleError(result, to_append_batch);
                 result.reset();

--- a/src/Service/RequestAccumulator.cpp
+++ b/src/Service/RequestAccumulator.cpp
@@ -2,6 +2,7 @@
 
 #include <Service/KeeperDispatcher.h>
 #include <Service/RequestAccumulator.h>
+#include <Service/Metrics.h>
 
 namespace RK
 {
@@ -34,6 +35,7 @@ void RequestAccumulator::run()
         {
             if (!requests_queue->tryPop(request_for_session))
             {
+                Metrics::getMetrics().BATCH_SIZE->add(to_append_batch.size());
                 result = server->pushRequestBatch(to_append_batch);
                 waitResultAndHandleError(result, to_append_batch);
                 result.reset();
@@ -49,6 +51,7 @@ void RequestAccumulator::run()
 
             if (to_append_batch.size() >= max_batch_size)
             {
+                Metrics::getMetrics().BATCH_SIZE->add(to_append_batch.size());
                 result = server->pushRequestBatch(to_append_batch);
                 waitResultAndHandleError(result, to_append_batch);
                 result.reset();

--- a/src/Service/RequestAccumulator.cpp
+++ b/src/Service/RequestAccumulator.cpp
@@ -35,7 +35,7 @@ void RequestAccumulator::run()
         {
             if (!requests_queue->tryPop(request_for_session))
             {
-                Metrics::getMetrics().BATCH_SIZE->add(to_append_batch.size());
+                Metrics::getMetrics().LOG_REPLICATION_BATCH_SIZE->add(to_append_batch.size());
                 result = server->pushRequestBatch(to_append_batch);
                 waitResultAndHandleError(result, to_append_batch);
                 result.reset();
@@ -51,7 +51,7 @@ void RequestAccumulator::run()
 
             if (to_append_batch.size() >= max_batch_size)
             {
-                Metrics::getMetrics().BATCH_SIZE->add(to_append_batch.size());
+                Metrics::getMetrics().LOG_REPLICATION_BATCH_SIZE->add(to_append_batch.size());
                 result = server->pushRequestBatch(to_append_batch);
                 waitResultAndHandleError(result, to_append_batch);
                 result.reset();

--- a/src/Service/RequestProcessor.cpp
+++ b/src/Service/RequestProcessor.cpp
@@ -88,12 +88,12 @@ void RequestProcessor::run()
                     });
             }
             request_thread->wait();
-            Metrics::getMetrics().APPLY_READ_REQUEST->add(watch.elapsedMilliseconds());
+            Metrics::getMetrics().apply_read_request_time_ms->add(watch.elapsedMilliseconds());
 
             /// 2. process committed request, single thread
             watch.restart();
             processCommittedRequest(committed_request_size);
-            Metrics::getMetrics().APPLY_WRITE_REQUEST->add(watch.elapsedMilliseconds());
+            Metrics::getMetrics().apply_write_request_time_ms->add(watch.elapsedMilliseconds());
 
             /// 3. process error requests
             processErrorRequest(error_request_size);
@@ -253,7 +253,7 @@ void RequestProcessor::processCommittedRequest(size_t count)
                 applyRequest(committed_request);
                 committed_queue.pop();
                 auto current_time = getCurrentTimeMilliseconds();
-                Metrics::getMetrics().UPDATE_LATENCY->add(current_time - committed_request.create_time);
+                Metrics::getMetrics().update_latency->add(current_time - committed_request.create_time);
 
                 /// remove request from pending queue
                 auto & pending_requests_for_session = my_pending_requests[committed_request.session_id];
@@ -434,7 +434,7 @@ void RequestProcessor::processReadRequests(RunnerId runner_id)
             {
                 applyRequest(*session_request);
                 auto current_time = getCurrentTimeMilliseconds();
-                Metrics::getMetrics().READ_LATENCY->add(current_time - session_request->create_time);
+                Metrics::getMetrics().read_latency->add(current_time - session_request->create_time);
                 session_request = session_requests.erase(session_request);
             }
             else

--- a/tests/integration/test_four_word_command/test.py
+++ b/tests/integration/test_four_word_command/test.py
@@ -172,7 +172,6 @@ def test_cmd_mntr(started_cluster):
         assert int(result["zk_outstanding_requests"]) == 0
 
         assert result["zk_server_state"] == "leader"
-        assert result["zk_is_leader"] == "1"
 
         # contains:
         #   10 nodes created by test

--- a/tests/integration/test_four_word_command/test.py
+++ b/tests/integration/test_four_word_command/test.py
@@ -479,10 +479,10 @@ def test_cmd_crst(started_cluster):
         assert len(cons) >= 2
 
         zk_con = None
-        if 'sid' in cons[0]:
-            zk_con = cons[0]
-        else:
-            zk_con = cons[1]
+        for con in cons:
+            if 'sid' in con:
+                zk_con = con
+        assert zk_con is not None
 
         conn_stat = re.match(r'(.*?)[:].*[(](.*?)[)].*', zk_con.strip(), re.S).group(2)
         assert conn_stat is not None


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR is part of issue #168

### Change log:
<!-- (Please describe the changes you have made in details. -->
Add those metrics 
- apply_read_request_time_ms: The time for request processor to process read request
- apply_write_request_time_ms: The time for request processor to process write request
- batch_size: Records the batch size of each batch accumulation for replication
- push_request_queue_time_ms: The time for push request from handler to dispatcher's request queue
- readlatency: Latency for read request. The timing start from when the server see the request until it leave final request processor
- updatelatency: Latency for write request. The timing start from when the server see the request until it leave final request processor
