### PR TITLE
Remove the use of thread pools for parallel processing of read request

### DIFF
--- a/src/Service/RequestProcessor.h
+++ b/src/Service/RequestProcessor.h
@@ -82,8 +82,6 @@ private:
 
     size_t runner_count;
 
-    ThreadPoolPtr request_thread;
-
     std::shared_ptr<KeeperDispatcher> keeper_dispatcher;
 
     mutable std::mutex mutex;


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #231
Before remove thread pools
![image](https://github.com/JDRaftKeeper/RaftKeeper/assets/49020515/2f3c98e6-9864-4646-9198-5723ef2c46ba)
Over 60% of the time in ReqProcessor is spent on `_pthread_cond_wait`.

After remove thread pools
![image](https://github.com/JDRaftKeeper/RaftKeeper/assets/49020515/c57ee3b5-c8c4-4281-b58f-a38071eeab28)

Result for benchmark
```
#Before remove thread pools
================= Result (Time measured in microsecond.) =================
thread_size,tps,avgRT(microsecond),TP90(microsecond),TP99(microsecond),TP999(microsecond),failRate
200,84416,2407.0,3800.0,4500.0,8300.0,0.0

#After remove thread pools
================= Result (Time measured in microsecond.) =================
thread_size,tps,avgRT(microsecond),TP90(microsecond),TP99(microsecond),TP999(microsecond),failRate
200,108950,1846.0,3100.0,4000.0,5600.0,0.0
```

### Change log:
<!-- (Please describe the changes you have made in details. -->
Remove the use of thread pools for parallel processing of read request
