### PR TITLE
Remove unnecessary locks in keeperStore

### DIFF
--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -42,8 +42,6 @@ struct KeeperNode
     Coordination::Stat stat{};
     ChildrenSet children{};
 
-    std::shared_mutex mutex;
-
     std::shared_ptr<KeeperNode> clone() const
     {
         auto node = std::make_shared<KeeperNode>();

--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -153,6 +153,17 @@ public:
         return false;
     }
 
+    template <typename T>
+    bool emplace(const String & key, T && value, UInt32 bucket_idx)
+    {
+        if (maps_[bucket_idx].emplace(key, std::forward<T>(value)))
+        {
+            node_count ++;
+            return true;
+        }
+        return false;
+    }
+
     bool erase(String const & key)
     {
         if (mapFor(key).erase(key))
@@ -210,6 +221,7 @@ public:
     /// Hold Edges in different Buckets based on the parent node's bucket number.
     /// It should be used when load snapshot to built node's childrenSet in parallel without lock.
     using BucketEdges = std::array<Edges, MAP_BUCKET_NUM>;
+    using BucketNodes = std::array<std::vector<std::pair<String, std::shared_ptr<KeeperNode>>>, MAP_BUCKET_NUM>;
 
     /// global session id counter, used to allocate new session id.
     /// It should be same across all nodes.
@@ -309,6 +321,8 @@ public:
 
     // Build childrenSet for the node in specified bucket after load data from snapshot.
     void buildBucketChildren(const std::vector<BucketEdges> & all_objects_edges, UInt32 bucket_idx);
+    void buildBucketNodes(const std::vector<BucketNodes> & all_objects_nodes, UInt32 bucket_idx);
+
 
     void finalize();
 

--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -79,10 +79,10 @@ struct KeeperNodeWithPath
     std::shared_ptr<KeeperNode> node;
 };
 
-/// ConcurrentMap is a two-level unordered_map which is designed
+/// KeeperNodeMap is a two-level unordered_map which is designed
 /// to reduce latency for unordered_map scales.
 template <typename Element, unsigned NumBuckets>
-class ConcurrentMap
+class KeeperNodeMap
 {
 public:
     using SharedElement = std::shared_ptr<Element>;
@@ -188,9 +188,9 @@ public:
 class KeeperStore
 {
 public:
-    /// bucket num for ConcurrentMap
+    /// bucket num for KeeperNodeMap
     static constexpr int MAP_BUCKET_NUM = 16;
-    using Container = ConcurrentMap<KeeperNode, MAP_BUCKET_NUM>;
+    using Container = KeeperNodeMap<KeeperNode, MAP_BUCKET_NUM>;
 
     using ResponsesForSessions = std::vector<ResponseForSession>;
     using KeeperResponsesQueue = ThreadSafeQueue<ResponseForSession>;

--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -136,7 +136,7 @@ public:
 private:
     std::array<InnerMap, NumBuckets> maps_;
     std::hash<String> hash_;
-    std::atomic<size_t> node_count;
+    std::atomic<size_t> node_count{0};
 
 public:
     SharedElement get(const String & key) { return mapFor(key).get(key); }

--- a/src/Service/NuRaftLogSnapshot.cpp
+++ b/src/Service/NuRaftLogSnapshot.cpp
@@ -84,11 +84,7 @@ void KeeperSnapshotStore::serializeNodeV2(
     if (!node)
         return;
 
-    std::shared_ptr<KeeperNode> node_copy;
-    {
-        std::shared_lock lock(node->mutex);
-        node_copy = node->clone();
-    }
+    std::shared_ptr<KeeperNode> node_copy = node->clone();
 
     if (processed % max_object_node_size == 0)
     {

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -102,14 +102,14 @@ private:
     void getObjectPath(ulong object_id, String & path);
 
     /// Parse an snapshot object. We should take the version from snapshot in general.
-    void parseObject(KeeperStore & store, String obj_path, BucketEdges &);
+    void parseObject(KeeperStore & store, String obj_path, BucketEdges &, BucketNodes &);
 
     /// Parse batch header in an object
     /// TODO use internal buffer
     void parseBatchHeader(ptr<std::fstream> fs, SnapshotBatchHeader & head);
 
     /// Parse a batch
-    void parseBatchBodyV2(KeeperStore & store, const String &, BucketEdges &, SnapshotVersion version_);
+    void parseBatchBodyV2(KeeperStore & store, const String &, BucketEdges &, BucketNodes &, SnapshotVersion version_);
 
     /// For snapshot version v2
     size_t serializeDataTreeV2(KeeperStore & storage);
@@ -150,6 +150,7 @@ private:
     std::map<ulong, String> objects_path;
 
     std::vector<BucketEdges> all_objects_edges;
+    std::vector<BucketNodes> all_objects_nodes;
 
     /// Appended to snapshot file name
     String curr_time;

--- a/src/Service/SnapshotCommon.h
+++ b/src/Service/SnapshotCommon.h
@@ -34,6 +34,7 @@ static constexpr UInt32 SAVE_BATCH_SIZE = 10000;
 using StringMap = std::unordered_map<String, String>;
 using IntMap = std::unordered_map<String, int64_t>;
 using BucketEdges = KeeperStore::BucketEdges;
+using BucketNodes = KeeperStore::BucketNodes;
 
 enum SnapshotVersion : uint8_t
 {
@@ -129,7 +130,7 @@ template <typename T>
 void serializeMapV2(T & snap_map, UInt32 save_batch_size, SnapshotVersion version, String & path);
 
 /// parse snapshot batch
-void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BucketEdges & buckets_edges, SnapshotVersion version);
+void parseBatchDataV2(KeeperStore & store, SnapshotBatchBody & batch, BucketEdges & buckets_edges, BucketNodes & bucket_nodes, SnapshotVersion version);
 void parseBatchSessionV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);
 void parseBatchAclMapV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);
 void parseBatchIntMapV2(KeeperStore & store, SnapshotBatchBody & batch, SnapshotVersion version);


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #239

### Change log:
<!-- (Please describe the changes you have made in details. -->
- remove node's lock
- remove nodeMap's lock

Slightly peformance improve
```
# before
thread_size,tps,avgRT(microsecond),TP90(microsecond),TP99(microsecond),TP999(microsecond),failRate
200,97658,2064.0,2900.0,3700.0,5200.0,0.0
200,97157,2066.0,2900.0,3800.0,6000.0,0.0
# after
thread_size,tps,avgRT(microsecond),TP90(microsecond),TP99(microsecond),TP999(microsecond),failRate
200,100083,2014.0,3000.0,3800.0,5500.0,0.0
200,99541,2025.0,3000.0,3700.0,5200.0,0.0
```