### PR TITLE
Add client_req_timeout parameter to Raft configuration

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -77,6 +77,9 @@
             <!-- NuRaft heart beat interval in millisecond, default is 500. -->
             <!-- <heart_beat_interval_ms>500</heart_beat_interval_ms> -->
 
+            <!-- NuRaft request operation timeout in millisecond, default is 3000. -->
+            <!-- <client_req_timeout_ms>3000</client_req_timeout_ms> -->
+
             <!-- NuRaft election timeout lower bound, default is 10s. -->
             <!-- <election_timeout_lower_bound_ms>10000</election_timeout_lower_bound_ms> -->
 

--- a/src/Service/KeeperServer.cpp
+++ b/src/Service/KeeperServer.cpp
@@ -54,6 +54,7 @@ namespace
     {
         params.heart_beat_interval_ = raft_settings->heart_beat_interval_ms;
         params.election_timeout_lower_bound_ = raft_settings->election_timeout_lower_bound_ms;
+        params.client_req_timeout_ = raft_settings->client_req_timeout_ms;
         params.election_timeout_upper_bound_ = raft_settings->election_timeout_upper_bound_ms;
         params.reserved_log_items_ = raft_settings->reserved_log_items;
         params.snapshot_distance_ = raft_settings->snapshot_distance;

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -72,6 +72,7 @@ void RaftSettings::loadFromConfig(const String & config_elem, const Poco::Util::
         }
         dead_session_check_period_ms = config.getUInt(get_key("dead_session_check_period_ms"), 500);
         heart_beat_interval_ms = config.getUInt(get_key("heart_beat_interval_ms"), 500);
+        client_req_timeout_ms = config.getUInt(get_key("client_req_timeout_ms"), 3000);
         election_timeout_lower_bound_ms = config.getUInt(get_key("election_timeout_lower_bound_ms"), 10000);
         election_timeout_upper_bound_ms = config.getUInt(get_key("election_timeout_upper_bound_ms"), 20000);
         reserved_log_items = config.getUInt(get_key("reserved_log_items"), 1000000);
@@ -107,6 +108,7 @@ RaftSettingsPtr RaftSettings::getDefault()
     settings->operation_timeout_ms = Coordination::DEFAULT_OPERATION_TIMEOUT_MS;
     settings->dead_session_check_period_ms = 500;
     settings->heart_beat_interval_ms = 500;
+    settings->client_req_timeout_ms = 3000;
     settings->election_timeout_lower_bound_ms = 10000;
     settings->election_timeout_upper_bound_ms = 20000;
     settings->reserved_log_items = 10000000;
@@ -189,6 +191,8 @@ void Settings::dump(WriteBufferFromOwnString & buf) const
 
     writeText("heart_beat_interval_ms=", buf);
     write_int(raft_settings->heart_beat_interval_ms);
+    writeText("client_req_timeout_ms=", buf);
+    write_int(raft_settings->client_req_timeout_ms);
     writeText("election_timeout_lower_bound_ms=", buf);
     write_int(raft_settings->election_timeout_lower_bound_ms);
     writeText("election_timeout_upper_bound_ms=", buf);

--- a/src/Service/Settings.h
+++ b/src/Service/Settings.h
@@ -84,6 +84,8 @@ struct RaftSettings
     UInt64 election_timeout_lower_bound_ms;
     /// Lower bound of election timer (avoid too often leader elections)
     UInt64 election_timeout_upper_bound_ms;
+    /// Raft operation timeout (just for data replication)
+    UInt64 client_req_timeout_ms;
     /// How many log items to store (don't remove during compaction)
     UInt64 reserved_log_items;
     /// How many log items we have to collect to write new snapshot00

--- a/tests/integration/test_four_word_command/test.py
+++ b/tests/integration/test_four_word_command/test.py
@@ -285,6 +285,7 @@ def test_cmd_conf(started_cluster):
         assert result["log_dir"] == "./data/log"
         assert result["snapshot_dir"] == "./data/snapshot"
 
+        assert result["client_req_timeout_ms"] == "3000"
         assert result["min_session_timeout_ms"] == "1000"
         assert result["max_session_timeout_ms"] == "30000"
         assert result["operation_timeout_ms"] == "1000"


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #245

### Change log:
<!-- (Please describe the changes you have made in details. -->
Add `client_req_timeout` parameter to control Raft replication timeout.
