### PR TITLE
Speed up data tree copying with SIMD and prefetching.

### DIFF
--- a/src/Service/KeeperStore.cpp
+++ b/src/Service/KeeperStore.cpp
@@ -1916,9 +1916,8 @@ std::shared_ptr<KeeperStore::BucketNodes> KeeperStore::dumpDataTree()
                         key_size += data_size;
 
                         String path_copied;
-                        path_copied.reserve(data_size);
-                        memcopy(path_copied.data(), it->first.data(), data_size);
                         path_copied.resize(data_size);
+                        memcopy(path_copied.data(), it->first.data(), data_size);
 
                         bucket_in_result.emplace_back(std::move(path_copied), it->second->cloneWithoutChildren());
 

--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <Service/ACLMap.h>
 #include <Service/SessionExpiryQueue.h>
+#include <Service/memcopy.h>
 #include <Service/ThreadSafeQueue.h>
 #include <Service/KeeperCommon.h>
 #include <Service/formatHex.h>
@@ -40,12 +41,15 @@ struct KeeperNode
     bool is_sequential = false;
 
     Coordination::Stat stat{};
-    ChildrenSet children{};
+    ChildrenSet children;
 
     std::shared_ptr<KeeperNode> clone() const
     {
         auto node = std::make_shared<KeeperNode>();
-        node->data = data;
+        auto data_size = data.size();
+        node->data.reserve(data_size);
+        memcopy(node->data.data(), data.data(), data_size);
+        node->data.resize(data_size);
         node->acl_id = acl_id;
         node->is_ephemeral = is_ephemeral;
         node->is_sequential = is_sequential;
@@ -57,7 +61,10 @@ struct KeeperNode
     std::shared_ptr<KeeperNode> cloneWithoutChildren() const
     {
         auto node = std::make_shared<KeeperNode>();
-        node->data = data;
+        auto data_size = data.size();
+        node->data.reserve(data_size);
+        memcopy(node->data.data(), data.data(), data_size);
+        node->data.resize(data_size);
         node->acl_id = acl_id;
         node->is_ephemeral = is_ephemeral;
         node->is_sequential = is_sequential;

--- a/src/Service/KeeperStore.h
+++ b/src/Service/KeeperStore.h
@@ -47,9 +47,8 @@ struct KeeperNode
     {
         auto node = std::make_shared<KeeperNode>();
         auto data_size = data.size();
-        node->data.reserve(data_size);
-        memcopy(node->data.data(), data.data(), data_size);
         node->data.resize(data_size);
+        memcopy(node->data.data(), data.data(), data_size);
         node->acl_id = acl_id;
         node->is_ephemeral = is_ephemeral;
         node->is_sequential = is_sequential;
@@ -62,9 +61,8 @@ struct KeeperNode
     {
         auto node = std::make_shared<KeeperNode>();
         auto data_size = data.size();
-        node->data.reserve(data_size);
-        memcopy(node->data.data(), data.data(), data_size);
         node->data.resize(data_size);
+        memcopy(node->data.data(), data.data(), data_size);
         node->acl_id = acl_id;
         node->is_ephemeral = is_ephemeral;
         node->is_sequential = is_sequential;

--- a/src/Service/NuRaftLogSnapshot.cpp
+++ b/src/Service/NuRaftLogSnapshot.cpp
@@ -121,7 +121,7 @@ void KeeperSnapshotStore::serializeNodeV2(
         /// for there are 4 objects before data objects
         getObjectPath(obj_id + 4, new_obj_path);
 
-        LOG_INFO(log, "Create new snapshot object {}, path {}", obj_id + 4, new_obj_path);
+        LOG_INFO(log, "Creating new snapshot object {}, path {}", obj_id + 4, new_obj_path);
         out = openFileAndWriteHeader(new_obj_path, version);
     }
 
@@ -185,7 +185,7 @@ uint32_t KeeperSnapshotStore::serializeNodeAsync(
                 /// for there are 4 objects before data objects
                 getObjectPath(obj_id + 4, new_obj_path);
 
-                LOG_INFO(log, "Create new snapshot object {}, path {}", obj_id + 4, new_obj_path);
+                LOG_INFO(log, "Creating new snapshot object {}, path {}", obj_id + 4, new_obj_path);
                 out = openFileAndWriteHeader(new_obj_path, version);
             }
 
@@ -747,7 +747,7 @@ size_t KeeperSnapshotManager::createSnapshotAsync(SnapTask & snap_task, Snapshot
     snap_store->init();
     LOG_INFO(
         log,
-        "Create snapshot last_log_term {}, last_log_idx {}, size {}, nodes {}, ephemeral nodes {}, sessions {}, session_id_counter {}, "
+        "Creating snapshot with last_log_term {}, last_log_idx {}, size {}, nodes {}, ephemeral nodes {}, sessions {}, session_id_counter {}, "
         "zxid {}",
         meta->get_last_log_term(),
         meta->get_last_log_idx(),
@@ -771,7 +771,7 @@ size_t KeeperSnapshotManager::createSnapshot(
     snap_store->init();
     LOG_INFO(
         log,
-        "Create snapshot last_log_term {}, last_log_idx {}, size {}, nodes {}, ephemeral nodes {}, sessions {}, session_id_counter {}, "
+        "Creating snapshot with last_log_term {}, last_log_idx {}, size {}, nodes {}, ephemeral nodes {}, sessions {}, session_id_counter {}, "
         "zxid {}",
         meta.get_last_log_term(),
         meta.get_last_log_idx(),

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -28,7 +28,7 @@ struct SnapTask
     SnapTask(const ptr<snapshot> & s_, KeeperStore & store, nuraft::async_result<bool>::handler_type & when_done_)
         : s(s_), next_zxid(store.zxid), next_session_id(store.session_id_counter), when_done(when_done_)
     {
-        auto log = &Poco::Logger::get("SnapTask");
+        auto * log = &Poco::Logger::get("SnapTask");
         session_and_timeout = store.getSessionTimeOut();
         session_count = session_and_timeout.size();
         session_and_auth = store.getSessionAuth();
@@ -36,7 +36,7 @@ struct SnapTask
         acl_map = store.acl_map.getMapping();
         Stopwatch watch;
         buckets_nodes = store.dumpDataTree();
-        LOG_INFO(log, "Dump dataTree costs {}ms", watch.elapsedMilliseconds());
+        LOG_INFO(log, "Dumping data tree costs {}ms", watch.elapsedMilliseconds());
         Metrics::getMetrics().snap_blocking_time_ms->add(watch.elapsedMilliseconds());
 
         for (auto && bucket : *buckets_nodes)

--- a/src/Service/NuRaftStateMachine.cpp
+++ b/src/Service/NuRaftStateMachine.cpp
@@ -170,7 +170,7 @@ void NuRaftStateMachine::snapThread()
             last_snapshot_time = Poco::Timestamp().epochMicroseconds();
             in_snapshot = false;
 
-            LOG_INFO(log, "Create snapshot time cost {} ms", Poco::Timestamp().epochMicroseconds() / 1000 - snap_start_time);
+            LOG_INFO(log, "Snapshot created time cost {} ms", Poco::Timestamp().epochMicroseconds() / 1000 - snap_start_time);
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }

--- a/src/Service/SnapshotCommon.cpp
+++ b/src/Service/SnapshotCommon.cpp
@@ -247,7 +247,7 @@ void serializeAclsV2(const NumToACLMap & acl_map, String path, UInt32 save_batch
 
     if (ephemerals.empty())
     {
-        LOG_INFO(log, "Create snapshot ephemeral nodes size is 0");
+        LOG_INFO(log, "Ephemeral nodes size is 0");
         return 0;
     }
 

--- a/src/Service/memcopy.h
+++ b/src/Service/memcopy.h
@@ -31,8 +31,7 @@ inline void memcopy(char * __restrict dst, const char * __restrict src, size_t n
         /// Avoid clang loop-idiom optimization, which transforms _mm_storeu_si128 to built-in memcpy
         __asm__ __volatile__("" : : : "memory");
     }
-    if (left > 0)
-        ::memcpy(dst, src, left);
+    ::memcpy(dst, src, left);
 }
 
 #elif defined(__aarch64__) && defined(__ARM_NEON)
@@ -49,8 +48,7 @@ inline void memcopy(char * __restrict dst, const char * __restrict src, size_t n
         src += 16;
         aligned_n -= 16;
     }
-    if (left > 0)
-        ::memcpy(dst, src, left);
+    ::memcpy(dst, src, left);
 }
 
 #else

--- a/src/Service/memcopy.h
+++ b/src/Service/memcopy.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#ifdef __SSE2__
+#    include <emmintrin.h>
+#endif
+
+#if defined(__aarch64__) && defined(__ARM_NEON)
+#    include <arm_neon.h>
+#    include <cstring>
+#    pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
+/** Memory copy with SIMD instructions. It is used in places where performance is critical for small blocks of memory.
+  */
+namespace RK
+{
+#ifdef __SSE2__
+
+inline void memcopy(char * __restrict dst, const char * __restrict src, size_t n)
+{
+    auto aligned_n = n / 16 * 16;
+    auto left = n - aligned_n;
+    while (aligned_n > 0)
+    {
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), _mm_loadu_si128(reinterpret_cast<const __m128i *>(src)));
+
+        dst += 16;
+        src += 16;
+        aligned_n -= 16;
+
+        /// Avoid clang loop-idiom optimization, which transforms _mm_storeu_si128 to built-in memcpy
+        __asm__ __volatile__("" : : : "memory");
+    }
+    if (left > 0)
+        ::memcpy(dst, src, left);
+}
+
+#elif defined(__aarch64__) && defined(__ARM_NEON)
+
+inline void memcopy(char * __restrict dst, const char * __restrict src, size_t n)
+{
+    auto aligned_n = n / 16 * 16;
+    auto left = n - aligned_n;
+    while (aligned_n > 0)
+    {
+        vst1q_s8(reinterpret_cast<signed char *>(dst), vld1q_s8(reinterpret_cast<const signed char *>(src)));
+
+        dst += 16;
+        src += 16;
+        aligned_n -= 16;
+    }
+    if (left > 0)
+        ::memcpy(dst, src, left);
+}
+
+#else
+
+inline void memcopy(void * __restrict dst, const void * __restrict src, size_t n)
+{
+    memcpy(dst, src, n);
+}
+
+#endif
+}


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #251

### Description
After #247 RaftKeeper extremely reduces the user request blocking time when creating snapshot. For an 60 million nodes keeper instance, the blocking time is about 4-5s.

But it can also speed up.

After optimization:

```
2024.05.09 23:40:51.343610 [ 1948078 ] <Information> SnapTask: Dumping data tree costs 3457ms
```

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Speed up data tree copying with SIMD and prefetching.