### PR TITLE
Fix endless loop in last commmitted index thread

### DIFF
--- a/src/Service/LastCommittedIndexManager.cpp
+++ b/src/Service/LastCommittedIndexManager.cpp
@@ -46,8 +46,6 @@ LastCommittedIndexManager::~LastCommittedIndexManager()
 void LastCommittedIndexManager::push(UInt64 index)
 {
     last_committed_index = index;
-    std::unique_lock lock(mutex);
-    cv.notify_all();
 }
 
 UInt64 LastCommittedIndexManager::get()
@@ -111,7 +109,6 @@ void LastCommittedIndexManager::persistThread()
         out.next();
 
         previous_persist_index = current_index;
-        previous_persist_time = getCurrentTimeMicroseconds();
     }
 }
 


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Fix endless loop in last commmitted index thread
- Remove lock when pushing to last committed index manager queue

![image](https://github.com/JDRaftKeeper/RaftKeeper/assets/3991709/1a73c60c-f844-4889-b39d-f266deb6fdff)
