### PR TITLE
Fix data race by using write-lock for session requests callback

### DIFF
--- a/src/Service/KeeperDispatcher.cpp
+++ b/src/Service/KeeperDispatcher.cpp
@@ -119,7 +119,8 @@ void KeeperDispatcher::invokeResponseCallBack(int64_t session_id, const Coordina
     /// session request
     if (unlikely(isSessionRequest(response->getOpNum())))
     {
-        std::shared_lock<std::shared_mutex> read_lock(response_callbacks_mutex);
+        /// We should use write-lock here for the callback will modify session_response_callbacks
+        std::unique_lock<std::shared_mutex> write_lock(response_callbacks_mutex);
         auto session_writer = session_response_callbacks.find(session_id); /// TODO session id == internal id?
         if (session_writer == session_response_callbacks.end())
             return;


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #276 

### Change log:
<!-- (Please describe the changes you have made in details. -->

Fix data race by using write-lock for session requests callback