### PR TITLE
Opimize too many `getsockname` system calls

### DIFF
--- a/src/Network/SocketReactor.cpp
+++ b/src/Network/SocketReactor.cpp
@@ -304,9 +304,7 @@ void SocketReactor::dispatch(SocketNotifierPtr & notifier, const Notification & 
     try
     {
         const auto & sock = notifier->getSocket();
-        const auto socket_name = sock.isStream() ? sock.address().toString() /// use local address for server socket
-                                                 : sock.peerAddress().toString(); /// use remote address for server socket
-        LOG_TRACE(log, "Dispatch event {} for {} ", notification.name(), socket_name);
+        LOG_TRACE(log, "Dispatch event {} for {} ", notification.name(), sock.isStream() ? sock.address().toString() : sock.peerAddress().toString());
         notifier->dispatch(notification);
     }
     catch (...)


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #282 

### Change log:
<!-- (Please describe the changes you have made in details. -->

1. Opimize too many `getsockname` system calls
