### PR TITLE
Fix creating snapshot too frequently caused by int32 overflow

### DIFF
--- a/src/Service/NuRaftStateMachine.cpp
+++ b/src/Service/NuRaftStateMachine.cpp
@@ -60,7 +60,7 @@ NuRaftStateMachine::NuRaftStateMachine(
     , responses_queue(responses_queue_)
     , request_processor(request_processor_)
     , last_committed_idx(0)
-    , snapshot_creating_interval(internal * 1000000)
+    , snapshot_creating_interval(static_cast<uint64_t>(internal) * 1000000)
     , last_snapshot_time(Poco::Timestamp().epochMicroseconds())
     , new_session_id_callback_mutex(new_session_id_callback_mutex_)
     , new_session_id_callback(new_session_id_callback_)

--- a/src/Service/NuRaftStateMachine.h
+++ b/src/Service/NuRaftStateMachine.h
@@ -323,7 +323,7 @@ private:
     ptr<KeeperSnapshotManager> snap_mgr;
 
     /// The minimal interval to create snapshot
-    int32_t snapshot_creating_interval;
+    uint64_t snapshot_creating_interval;
 
     std::atomic<int64_t> last_snapshot_time;
 

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -246,8 +246,8 @@ SettingsPtr Settings::loadFromConfig(const Poco::Util::AbstractConfiguration & c
     ret->internal_port = config.getInt("keeper.internal_port", 8103);
     ret->thread_count = config.getInt("keeper.thread_count", getNumberOfPhysicalCPUCores());
 
-    ret->snapshot_create_interval = config.getInt("keeper.snapshot_create_interval", 3600);
-    ret->snapshot_create_interval = std::max(ret->snapshot_create_interval, 1);
+    ret->snapshot_create_interval = config.getUInt("keeper.snapshot_create_interval", 3600);
+    ret->snapshot_create_interval = std::max(ret->snapshot_create_interval, 1U);
 
     ret->super_digest = config.getString("keeper.superdigest", "");
 

--- a/src/Service/Settings.h
+++ b/src/Service/Settings.h
@@ -48,7 +48,7 @@ struct Settings
     String log_dir;
     String snapshot_dir;
 
-    int32_t snapshot_create_interval;
+    uint32_t snapshot_create_interval;
     int32_t thread_count;
 
     String four_letter_word_white_list;


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #306

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Fix creating snapshot too frequently caused int32 overflow