### PR TITLE
Fix snapshot never clear

### DIFF
--- a/src/Service/NuRaftLogSnapshot.cpp
+++ b/src/Service/NuRaftLogSnapshot.cpp
@@ -917,7 +917,7 @@ size_t KeeperSnapshotManager::removeSnapshots()
 {
     Int64 remove_count = static_cast<Int64>(snapshots.size()) - static_cast<Int64>(keep_max_snapshot_count);
 
-    LOG_INFO(log, "Remove index");
+    LOG_INFO(log, "There are {} snapshots, we will try to move {remove_count} of them", snapshots.size(), remove_count);
 
     while (remove_count > 0)
     {
@@ -965,6 +965,11 @@ size_t KeeperSnapshotManager::removeSnapshots()
         }
         remove_count--;
     }
+
+    if (snapshots.size() > keep_max_snapshot_count)
+        LOG_ERROR(log, "Snapshots size() is still large than keep_max_snapshot_count {}, it's a bug",
+                  snapshots.size(), keep_max_snapshot_count);
+
     return snapshots.size();
 }
 

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -285,6 +285,11 @@ inline uint128_t getSnapshotStoreMapKey(const SnapObject & obj)
     return getSnapshotStoreMapKeyImpl(obj.log_last_term, obj.log_last_index);
 }
 
+inline std::pair<uint64_t, uint64_t> getTermLogFromSnapshotStoreMapKey(uint128_t & key)
+{
+    return {static_cast<uint64_t>(key >> 64), static_cast<uint64_t>(key & 0xFFFFFFFFFFFFFFFF)};
+}
+
 // Map key is term << 64 | log
 using KeeperSnapshotStoreMap = std::map<uint128_t, ptr<KeeperSnapshotStore>>;
 

--- a/tests/integration/helpers/cluster_service.py
+++ b/tests/integration/helpers/cluster_service.py
@@ -777,6 +777,10 @@ class RaftKeeperInstance:
         return self.exec_in_container(
             ["bash", "-c", "echo $(if [ -e '{}' ]; then echo 'yes'; else echo 'no'; fi)".format(path)]) == 'yes\n'
 
+    def list_path(self, path):
+        return self.exec_in_container(
+            ["bash", "-c", "ls {}".format(path)])
+
     def copy_file_to_container(self, local_path, dest_path):
         container_id = self.get_docker_handle().id
         return self.cluster.copy_file_to_container(container_id, local_path, dest_path)

--- a/tests/integration/test_snapshots/configs/enable_async_snapshot_keeper.xml
+++ b/tests/integration/test_snapshots/configs/enable_async_snapshot_keeper.xml
@@ -2,8 +2,8 @@
 <keeper>
     <my_id>1</my_id>
     <host>node</host>
-    <log_dir>./raft_log</log_dir>
-    <snapshot_dir>./snapshot_log</snapshot_dir>
+    <log_dir>/raft_log</log_dir>
+    <snapshot_dir>/snapshot</snapshot_dir>
     <snapshot_create_interval>86400</snapshot_create_interval>
     <forwarding_port>8102</forwarding_port>
     <port>8101</port>
@@ -15,6 +15,7 @@
         <max_session_timeout_ms>80000</max_session_timeout_ms>
         <operation_timeout_ms>1000</operation_timeout_ms>
         <snapshot_distance>10</snapshot_distance>
+        <max_stored_snapshots>1</max_stored_snapshots>
         <election_timeout_lower_bound_ms>1000</election_timeout_lower_bound_ms>
         <election_timeout_upper_bound_ms>2000</election_timeout_upper_bound_ms>
         <min_session_timeout_ms>1000</min_session_timeout_ms>

--- a/tests/integration/test_snapshots/configs/enable_keeper.xml
+++ b/tests/integration/test_snapshots/configs/enable_keeper.xml
@@ -2,8 +2,8 @@
 <keeper>
     <my_id>1</my_id>
     <host>node</host>
-    <log_dir>./raft_log</log_dir>
-    <snapshot_dir>./snapshot_log</snapshot_dir>
+    <log_dir>/raft_log</log_dir>
+    <snapshot_dir>/snapshot</snapshot_dir>
     <snapshot_create_interval>86400</snapshot_create_interval>
     <forwarding_port>8102</forwarding_port>
     <port>8101</port>
@@ -15,6 +15,7 @@
         <max_session_timeout_ms>80000</max_session_timeout_ms>
         <operation_timeout_ms>1000</operation_timeout_ms>
         <snapshot_distance>10</snapshot_distance>
+        <max_stored_snapshots>1</max_stored_snapshots>
         <election_timeout_lower_bound_ms>1000</election_timeout_lower_bound_ms>
         <election_timeout_upper_bound_ms>2000</election_timeout_upper_bound_ms>
         <min_session_timeout_ms>1000</min_session_timeout_ms>


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #322

snapshots use term + log_index as map key since #296, we still use log_index to got snapshot to clear. So when snapshots will never update.

### Change log:
<!-- (Please describe the changes you have made in details. -->

