### PR TITLE
Add ability to turn OFF -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,10 @@ else ()
 endif ()
 
 
-add_warning(error)
+option(WERROR "Enable -Werror compiler option" ON)
+if (WERROR)
+    add_warning(error)
+endif()
 
 # Make this extra-checks for correct library dependencies.
 if (OS_LINUX AND NOT SANITIZE)


### PR DESCRIPTION
Right now there are couple of warnings:
- /src/ch/3rd-party/RaftKeeper/base/common/types.h:269:5: error: 'switch' missing 'default' label [-Werror,-Wswitch-default]
- /src/ch/3rd-party/RaftKeeper/src/Common/ThreadProfileEvents.cpp:67:5: error: 'switch' missing 'default' label [-Werror,-Wswitch-default]
- /src/ch/3rd-party/RaftKeeper/base/common/StringRef.h:122:5: error: 'switch' missing 'default' label [-Werror,-Wswitch-default]

And likely others