### PR TITLE
Add min parallel to four

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -53,7 +53,7 @@
         <!-- Max snapshot interval in second. -->
         <!-- <snapshot_create_interval>3600</snapshot_create_interval> -->
 
-        <!-- Processor parallel, default is CPU core size. For container is cgroup limit size. -->
+        <!-- Processor parallel, default is CPU core size, for container is cgroup limit size, note that it is not lower than 4. -->
         <!-- <parallel></parallel> -->
 
         <!-- 4lwd command white list, default "conf,cons,crst,envi,ruok,srst,srvr,stat,wchs,dirs,mntr,isro,lgif,rqld,uptm,csnp" -->

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -243,7 +243,7 @@ SettingsPtr Settings::loadFromConfig(const Poco::Util::AbstractConfiguration & c
     ret->host = config.getString("keeper.host", "0.0.0.0");
 
     ret->internal_port = config.getInt("keeper.internal_port", 8103);
-    ret->parallel = config.getInt("keeper.parallel", getNumberOfPhysicalCPUCores());
+    ret->parallel = config.getInt("keeper.parallel", std::max(4U, getNumberOfPhysicalCPUCores()));
 
     ret->snapshot_create_interval = config.getUInt("keeper.snapshot_create_interval", 3600);
     ret->snapshot_create_interval = std::max(ret->snapshot_create_interval, 1U);


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #344 

The follow testing is based on a 3-node cluster in which the node has only 1 core. 
```
parallel: 1
Benchmark result(time measured in microsecond):
parallel,tps,avgRT(us),TP90(us),TP99(us),TP999(us),wall_time(us),total_time(us),total_request,fail_request
300,60750,4899,2100.0,74300.0,100600.0,32708142,9525223470,1944000,0

parallel: 4
Benchmark result(time measured in microsecond):
parallel,tps,avgRT(us),TP90(us),TP99(us),TP999(us),wall_time(us),total_time(us),total_request,fail_request
300,63250,4705,2100.0,74700.0,89400.0,32843298,9524420480,2024000,0
```

### Change log:
<!-- (Please describe the changes you have made in details. -->

- Add min parallel to 4