### PR TITLE
Remove raftkeeper 1.0 only code

### DIFF
--- a/docs/how-to-monitor-and-manage.md
+++ b/docs/how-to-monitor-and-manage.md
@@ -193,7 +193,6 @@ max_stored_snapshots=5
 shutdown_timeout=5000
 startup_timeout=6000000
 raft_logs_level=information
-rotate_log_storage_interval=100000
 log_fsync_mode=fsync_parallel
 log_fsync_interval=1000
 nuraft_thread_size=16

--- a/src/Service/ConnectionHandler.h
+++ b/src/Service/ConnectionHandler.h
@@ -8,6 +8,7 @@
 #include <Poco/Thread.h>
 #include <Poco/Util/ServerApplication.h>
 
+#include <Common/IO/ReadBufferFromString.h>
 #include <Common/IO/WriteBufferFromString.h>
 #include <Network/SocketAcceptor.h>
 #include <Network/SocketNotification.h>
@@ -62,7 +63,6 @@ public:
     void onSocketError(const Notification &);
 
     /// current connection statistics
-    ConnectionStats getConnectionStats() const;
     void dumpStats(WriteBufferFromOwnString & buf, bool brief);
 
     /// reset current connection statistics

--- a/src/Service/ForwardConnectionHandler.h
+++ b/src/Service/ForwardConnectionHandler.h
@@ -4,6 +4,7 @@
 #include <Poco/Net/StreamSocket.h>
 #include <Poco/Thread.h>
 
+#include <Common/IO/ReadBufferFromString.h>
 #include <Network/SocketAcceptor.h>
 #include <Network/SocketNotification.h>
 #include <Network/SocketReactor.h>

--- a/src/Service/FourLetterCommand.cpp
+++ b/src/Service/FourLetterCommand.cpp
@@ -8,7 +8,6 @@
 #include <Poco/Environment.h>
 #include <Poco/Path.h>
 #include <Poco/String.h>
-#include "Common/StringUtils.h"
 #include <Common/config_version.h>
 #include <Common/getCurrentProcessFDCount.h>
 #include <Common/getMaxFileDescriptorCount.h>
@@ -258,7 +257,7 @@ String MonitorCommand::run()
     print(ret, "watch_count", state_machine.getTotalWatchesCount());
     print(ret, "ephemerals_count", state_machine.getTotalEphemeralNodesCount());
     print(ret, "approximate_data_size", state_machine.getApproximateDataSize());
-    print(ret, "in_snapshot", state_machine.getSnapshoting());
+    print(ret, "in_snapshot", state_machine.isCreatingSnapshot());
 
 #if defined(__linux__) || defined(__APPLE__)
     print(ret, "open_file_descriptor_count", getCurrentProcessFDCount());

--- a/src/Service/KeeperServer.cpp
+++ b/src/Service/KeeperServer.cpp
@@ -135,10 +135,10 @@ ptr<nuraft::cmd_result<ptr<buffer>>> KeeperServer::pushRequestBatch(const std::v
 {
     LOG_DEBUG(log, "Push batch requests of size {}", request_batch.size());
     std::vector<ptr<buffer>> entries;
-    for (const auto & request_session : request_batch)
+    for (const auto & request : request_batch)
     {
-        LOG_TRACE(log, "Push request {}", request_session.toSimpleString());
-        entries.push_back(serializeKeeperRequest(request_session));
+        LOG_TRACE(log, "Push request {}", request.toSimpleString());
+        entries.push_back(serializeKeeperRequest(request));
     }
     /// append_entries write request
     ptr<nuraft::cmd_result<ptr<buffer>>> result = raft_instance->append_entries(entries);

--- a/src/Service/KeeperUtils.h
+++ b/src/Service/KeeperUtils.h
@@ -1,22 +1,29 @@
 #pragma once
 
 #include <fstream>
-#include <time.h>
-#include <Service/Crc32.h>
 #include <ZooKeeper/IKeeper.h>
 #include <ZooKeeper/ZooKeeperCommon.h>
 #include <libnuraft/log_entry.hxx>
 #include <libnuraft/nuraft.hxx>
-#include <common/logger_useful.h>
 #include <Service/KeeperCommon.h>
 
 
 namespace RK
 {
 
+inline UInt64 getCurrentTimeMilliseconds()
+{
+    return duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+inline UInt64 getCurrentTimeMicroseconds()
+{
+    return duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
 /// Serialize and deserialize ZooKeeper request to log
 nuraft::ptr<nuraft::buffer> serializeKeeperRequest(const RequestForSession & request);
-RequestForSession deserializeKeeperRequest(nuraft::buffer & data);
+nuraft::ptr<RequestForSession> deserializeKeeperRequest(nuraft::buffer & data);
 
 nuraft::ptr<nuraft::log_entry> cloneLogEntry(const nuraft::ptr<nuraft::log_entry> & entry);
 

--- a/src/Service/LastCommittedIndexManager.h
+++ b/src/Service/LastCommittedIndexManager.h
@@ -38,7 +38,7 @@ private:
     UInt64 static constexpr PERSIST_INTERVAL_US = 100 * 1000;
     std::string_view static constexpr FILE_NAME = "last_committed_index.bin";
 
-    ThreadFromGlobalPool persist_thread;
+    ThreadFromGlobalPool bg_persist_thread;
     std::atomic<bool> is_shut_down{false};
 
     String persist_file_name;

--- a/src/Service/Metrics.h
+++ b/src/Service/Metrics.h
@@ -13,11 +13,6 @@
 namespace RK
 {
 
-inline UInt64 getCurrentTimeMilliseconds()
-{
-    return duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
-};
-
 
 /**
  * Uses the reservoir sampling algorithm to sample statistical values

--- a/src/Service/NuRaftLogSnapshot.cpp
+++ b/src/Service/NuRaftLogSnapshot.cpp
@@ -5,8 +5,6 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#include <common/find_symbols.h>
-
 #include <Poco/DateTime.h>
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/File.h>
@@ -15,6 +13,7 @@
 #include <Common/Exception.h>
 #include <Common/Stopwatch.h>
 
+#include <Service/Crc32.h>
 #include <Service/KeeperUtils.h>
 #include <Service/NuRaftLogSnapshot.h>
 #include <Service/ReadBufferFromNuRaftBuffer.h>
@@ -776,12 +775,12 @@ bool KeeperSnapshotManager::receiveSnapshotMeta(snapshot & meta)
     return true;
 }
 
-bool KeeperSnapshotManager::existSnapshot(const snapshot & meta)
+bool KeeperSnapshotManager::existSnapshot(const snapshot & meta) const
 {
     return snapshots.find(getSnapshotStoreMapKey(meta)) != snapshots.end();
 }
 
-bool KeeperSnapshotManager::existSnapshotObject(const snapshot & meta, ulong obj_id)
+bool KeeperSnapshotManager::existSnapshotObject(const snapshot & meta, ulong obj_id) const
 {
     auto it = snapshots.find(getSnapshotStoreMapKey(meta));
     if (it == snapshots.end())

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -327,10 +327,10 @@ public:
     bool saveSnapshotObject(snapshot & meta, ulong obj_id, buffer & buffer);
 
     /// whether snapshot exists
-    bool existSnapshot(const snapshot & meta);
+    bool existSnapshot(const snapshot & meta) const;
 
     /// whether snapshot object exists
-    bool existSnapshotObject(const snapshot & meta, ulong obj_id);
+    bool existSnapshotObject(const snapshot & meta, ulong obj_id) const;
 
     /// load snapshot object, invoked when leader should send snapshot to others.
     bool loadSnapshotObject(const snapshot & meta, ulong obj_id, ptr<buffer> & buffer);

--- a/src/Service/NuRaftStateMachine.cpp
+++ b/src/Service/NuRaftStateMachine.cpp
@@ -2,21 +2,14 @@
 #include <mutex>
 #include <string>
 
-#include <Poco/File.h>
-
-#include <Common/Stopwatch.h>
 #include <Common/setThreadName.h>
 
 #include <Service/NuRaftFileLogStore.h>
 #include <Service/NuRaftStateMachine.h>
-#include <Service/ReadBufferFromNuRaftBuffer.h>
 #include <Service/RequestProcessor.h>
 #include <Service/ThreadSafeQueue.h>
-#include <Service/WriteBufferFromNuraftBuffer.h>
 #include <ZooKeeper/ZooKeeperIO.h>
 
-
-using namespace nuraft;
 
 namespace RK
 {
@@ -32,8 +25,8 @@ struct ReplayLogBatch
 {
     ulong batch_start_index = 0;
     ulong batch_end_index = 0;
-    ptr<std::vector<LogEntryWithVersion>> log_vec;
-    ptr<std::vector<ptr<RequestForSession>>> request_vec;
+    ptr<std::vector<LogEntryWithVersion>> log_entries;
+    ptr<std::vector<ptr<RequestForSession>>> requests;
 };
 
 NuRaftStateMachine::NuRaftStateMachine(
@@ -55,12 +48,11 @@ NuRaftStateMachine::NuRaftStateMachine(
     , request_processor(request_processor_)
     , last_committed_idx(0)
     , snapshot_creating_interval(static_cast<uint64_t>(internal) * 1000000)
-    , last_snapshot_time(Poco::Timestamp().epochMicroseconds())
+    , last_snapshot_time(getCurrentTimeMicroseconds())
     , new_session_id_callback_mutex(new_session_id_callback_mutex_)
     , new_session_id_callback(new_session_id_callback_)
+    , log(&(Poco::Logger::get("KeeperStateMachine")))
 {
-    log = &(Poco::Logger::get("KeeperStateMachine"));
-
     LOG_INFO(log, "Begin to initialize state machine");
 
     snapshot_dir = snap_dir;
@@ -68,16 +60,15 @@ NuRaftStateMachine::NuRaftStateMachine(
 
     /// Load snapshot meta from disk
     auto snapshots_count = snap_mgr->loadSnapshotMetas();
+
     LOG_INFO(log, "Found {} snapshots from disk, load the latest one", snapshots_count);
-    auto last_snapshot = snap_mgr->lastSnapshot();
-    if (last_snapshot != nullptr)
+    if (auto last_snapshot = snap_mgr->lastSnapshot())
         applySnapshotImpl(*last_snapshot);
 
     committed_log_manager = cs_new<LastCommittedIndexManager>(log_dir);
-    /// Last committed idx of the previous startup, we should apply log to here.
-    uint64_t previous_last_commit_id = committed_log_manager->get();
 
-    if (!previous_last_commit_id)
+    /// Last committed idx of the previous startup, we should apply log to here.
+    if (uint64_t previous_last_commit_id = committed_log_manager->get(); previous_last_commit_id == 0)
     {
         LOG_INFO(log, "No previous last commit idx found, skip replaying logs.");
     }
@@ -109,54 +100,14 @@ NuRaftStateMachine::NuRaftStateMachine(
         store.getZxid());
 
     store.initializeSystemNodes();
-
-    LOG_INFO(log, "Starting background creating snapshot thread.");
-    snap_thread = ThreadFromGlobalPool([this] { snapThread(); });
-}
-
-ptr<RequestForSession> NuRaftStateMachine::createRequestSession(ptr<log_entry> & entry)
-{
-    if (entry->get_val_type() != nuraft::log_val_type::app_log)
-        return nullptr;
-
-    ReadBufferFromNuRaftBuffer buffer(entry->get_buf());
-    ptr<RequestForSession> request_for_session = cs_new<RequestForSession>();
-
-    readIntBinary(request_for_session->session_id, buffer);
-    if (buffer.eof())
-    {
-        LOG_DEBUG(log, "session time out {}", toHexString(request_for_session->session_id));
-        return nullptr;
-    }
-
-    int32_t length;
-    Coordination::read(length, buffer);
-    if (length <= 0)
-    {
-        return nullptr;
-    }
-
-    int32_t xid;
-    Coordination::read(xid, buffer);
-
-    Coordination::OpNum opnum;
-    Coordination::read(opnum, buffer);
-
-    request_for_session->request = Coordination::ZooKeeperRequestFactory::instance().get(opnum);
-    request_for_session->request->xid = xid;
-    request_for_session->request->readImpl(buffer);
-
-    if (buffer.eof())
-        request_for_session->create_time = getCurrentTimeMilliseconds();
-    else
-        Coordination::read(request_for_session->create_time, buffer);
-
-    return request_for_session;
+    bg_snap_thread = ThreadFromGlobalPool([this] { snapThread(); });
 }
 
 void NuRaftStateMachine::snapThread()
 {
+    LOG_INFO(log, "Starting background creating snapshot thread.");
     setThreadName("snapThread");
+
     while (!shutdown_called)
     {
         if (snap_task_ready)
@@ -177,20 +128,19 @@ void NuRaftStateMachine::snapThread()
             current_task->when_done(ret, except);
 
             Metrics::getMetrics().snap_count->add(1);
-            Metrics::getMetrics().snap_time_ms->add(Poco::Timestamp().epochMicroseconds() / 1000 - snap_start_time);
+            Metrics::getMetrics().snap_time_ms->add(getCurrentTimeMilliseconds() - snap_start_time);
 
-            last_snapshot_time = Poco::Timestamp().epochMicroseconds();
+            last_snapshot_time = getCurrentTimeMicroseconds();
             in_snapshot = false;
 
-            LOG_INFO(log, "Snapshot created time cost {} ms", Poco::Timestamp().epochMicroseconds() / 1000 - snap_start_time);
+            LOG_INFO(log, "Snapshot created time cost {} ms", getCurrentTimeMilliseconds() - snap_start_time);
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
 }
 
-ptr<buffer> NuRaftStateMachine::pre_commit(const ulong log_idx, buffer & data)
+ptr<buffer> NuRaftStateMachine::pre_commit(const ulong, buffer &)
 {
-    LOG_TRACE(log, "pre commit, log index {}, data size {}", log_idx, data.size());
     return nullptr;
 }
 
@@ -200,92 +150,388 @@ void NuRaftStateMachine::rollback(const ulong log_idx, buffer & data)
     LOG_TRACE(log, "pre commit, log index {}, data size {}", log_idx, data.size());
 }
 
-nuraft::ptr<nuraft::buffer> NuRaftStateMachine::commit(const ulong log_idx, nuraft::buffer & data, bool ignore_response)
+ptr<buffer> NuRaftStateMachine::commit(const ulong log_idx, buffer & data, bool ignore_response)
 {
-    LOG_TRACE(log, "Begin commit log index {}", log_idx);
+    auto request_for_session = deserializeKeeperRequest(data);
+    LOG_TRACE(log, "Commit log {}, request {}", log_idx, request_for_session->toSimpleString());
 
-    if (isNewSessionRequest(data)) /// TODO remove in future
-    {
-        nuraft::buffer_serializer timeout_data(data);
-        int64_t session_timeout_ms = timeout_data.get_i64();
-
-        auto response = nuraft::buffer::alloc(sizeof(int64_t));
-        int64_t session_id;
-
-        nuraft::buffer_serializer bs(response);
-        {
-            std::unique_lock session_id_lock(new_session_id_callback_mutex);
-            session_id = store.getSessionID(session_timeout_ms);
-            bs.put_i64(session_id);
-
-            LOG_DEBUG(log, "Commit session id {} with timeout {}", toHexString(session_id), session_timeout_ms);
-
-            last_committed_idx = log_idx;
-            committed_log_manager->push(last_committed_idx);
-
-            if (new_session_id_callback.contains(session_id))
-                new_session_id_callback.find(session_id)->second->notify_all();
-            else
-                LOG_DEBUG(
-                    log,
-                    "Not found callback for session id {}, maybe time out or before wait or not allocate from local",
-                    toHexString(session_id));
-        }
-
-        return response;
-    }
-    else if (isUpdateSessionRequest(data)) /// TODO remove in future
-    {
-        nuraft::buffer_serializer data_serializer(data);
-        int64_t session_id = data_serializer.get_i64();
-        int64_t session_timeout_ms = data_serializer.get_i64();
-
-        auto response = nuraft::buffer::alloc(1);
-        nuraft::buffer_serializer bs(response);
-
-        {
-            std::unique_lock session_id_lock(new_session_id_callback_mutex);
-            int8_t is_success = store.updateSessionTimeout(session_id, session_timeout_ms);
-            bs.put_i8(is_success);
-
-            LOG_DEBUG(log, "Update session id {} with timeout {}, response {}", toHexString(session_id), session_timeout_ms, is_success);
-            last_committed_idx = log_idx;
-            committed_log_manager->push(last_committed_idx);
-
-            if (new_session_id_callback.contains(session_id))
-                new_session_id_callback.find(session_id)->second->notify_all();
-            else
-                LOG_DEBUG(
-                    log,
-                    "Not found callback for session id {}, maybe time out or before wait or not allocate from local",
-                    toHexString(session_id));
-        }
-
-        return response;
-    }
+    if (request_processor)
+        request_processor->commit(*request_for_session);
     else
-    {
-        auto request_for_session = deserializeKeeperRequest(data);
-        LOG_TRACE(log, "Commit log index {}, request {}", log_idx, request_for_session.toSimpleString());
+        store.processRequest(responses_queue, *request_for_session, {}, true, ignore_response);
 
-        if (request_processor)
-            request_processor->commit(request_for_session);
-        else
-            store.processRequest(responses_queue, request_for_session, {}, true, ignore_response);
+    last_committed_idx = log_idx;
+    committed_log_manager->push(last_committed_idx);
 
-        last_committed_idx = log_idx;
-        committed_log_manager->push(last_committed_idx);
-
-        return nullptr;
-    }
+    return nullptr;
 }
 
-nuraft::ptr<nuraft::buffer> NuRaftStateMachine::commit(const ulong log_idx, buffer & data)
+ptr<buffer> NuRaftStateMachine::commit(const ulong log_idx, buffer & data)
 {
     return commit(log_idx, data, false);
 }
 
-std::vector<int64_t> NuRaftStateMachine::getDeadSessions()
+void NuRaftStateMachine::shutdown()
+{
+    if (shutdown_called)
+        return;
+
+    shutdown_called = true;
+    LOG_INFO(log, "Shutting down state machine");
+
+    store.finalize();
+    committed_log_manager->shutDown();
+    bg_snap_thread.join();
+    LOG_INFO(log, "State machine shut down done!");
+}
+
+bool NuRaftStateMachine::chk_create_snapshot()
+{
+    Poco::Timestamp now;
+    return !in_snapshot && now > last_snapshot_time + snapshot_creating_interval;
+}
+
+void NuRaftStateMachine::create_snapshot(snapshot & s, async_result<bool>::handler_type & when_done)
+{
+    size_t wait_times = 0;
+    while (request_processor && request_processor->commitQueueSize() != 0)
+    {
+        /// wait commit queue empty
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        if (++wait_times % 1000 == 0)
+        {
+            LOG_WARNING(log, "Wait commit queue to empty");
+        }
+    }
+
+    in_snapshot = true;
+    snap_start_time = getCurrentTimeMilliseconds();
+
+    LOG_INFO(log, "Creating snapshot last_log_term {}, last_log_idx {}", s.get_last_log_term(), s.get_last_log_idx());
+
+    if (!raft_settings->async_snapshot)
+    {
+        create_snapshot(s, store.getZxid(), store.getSessionIDCounter());
+        ptr<std::exception> except(nullptr);
+        bool ret = true;
+        when_done(ret, except);
+
+        Metrics::getMetrics().snap_count->add(1);
+        Metrics::getMetrics().snap_time_ms->add(getCurrentTimeMilliseconds() - snap_start_time);
+
+        last_snapshot_time = getCurrentTimeMicroseconds();
+        in_snapshot = false;
+
+        LOG_INFO(log, "Created snapshot, time cost {} ms", getCurrentTimeMilliseconds() - snap_start_time);
+    }
+    else
+    {
+        /// Need make a copy of s
+        ptr<buffer> snp_buf = s.serialize();
+        auto snap_copy = snapshot::deserialize(*snp_buf);
+        snap_task = std::make_shared<SnapTask>(snap_copy, store, when_done);
+        snap_task_ready = true;
+
+        LOG_INFO(log, "Scheduling asynchronous creating snapshot task, time cost {} ms", getCurrentTimeMilliseconds() - snap_start_time);
+    }
+}
+
+void NuRaftStateMachine::create_snapshot(snapshot & s, int64_t next_zxid, int64_t next_session_id)
+{
+    std::lock_guard lock(snapshot_mutex);
+    snap_mgr->createSnapshot(s, store, next_zxid, next_session_id);
+    snap_mgr->removeSnapshots();
+}
+
+void NuRaftStateMachine::create_snapshot_async(SnapTask & s)
+{
+    std::lock_guard lock(snapshot_mutex);
+    snap_mgr->createSnapshotAsync(s);
+    snap_mgr->removeSnapshots();
+}
+
+void NuRaftStateMachine::save_snapshot_data(snapshot &, const ulong, buffer &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "method is deprecated");
+}
+
+int NuRaftStateMachine::read_snapshot_data(snapshot &, const ulong, buffer &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "method is deprecated");
+}
+
+int NuRaftStateMachine::read_logical_snp_obj(snapshot & s, void *& user_snp_ctx, ulong obj_id, ptr<buffer> & data_out, bool & is_last_obj)
+{
+    std::lock_guard<std::mutex> lock(snapshot_mutex);
+    if (!snap_mgr->existSnapshot(s))
+    {
+        data_out = nullptr;
+        is_last_obj = true;
+        LOG_INFO(log, "Can't find snapshot by last_log_idx {}, object id {}", s.get_last_log_idx(), obj_id);
+        return 0;
+    }
+
+    if (obj_id == 0)
+    {
+        // Object ID == 0: first object
+        data_out = buffer::alloc(sizeof(UInt32));
+        nuraft::buffer_serializer bs(data_out);
+        bs.put_i32(0);
+        is_last_obj = false;
+        LOG_INFO(log, "Read snapshot object, last_log_idx {}, object id {}, is_last {}", s.get_last_log_idx(), obj_id, false);
+        return 0;
+    }
+
+    // Object ID > 0: second object, put actual value.
+    snap_mgr->loadSnapshotObject(s, obj_id, data_out);
+    is_last_obj = !(snap_mgr->existSnapshotObject(s, obj_id + 1));
+
+    LOG_INFO(log, "Read snapshot object, last_log_idx {}, object id {}, is_last {}", s.get_last_log_idx(), obj_id, is_last_obj);
+    user_snp_ctx = nullptr;
+
+    return 0;
+}
+
+void NuRaftStateMachine::save_logical_snp_obj(snapshot & s, ulong & obj_id, buffer & data, bool is_first_obj, bool is_last_obj)
+{
+    if (obj_id == 0)
+    {
+        // Object ID == 0: it contains dummy value, create snapshot context.
+        snap_mgr->receiveSnapshotMeta(s);
+    }
+    else
+    {
+        std::lock_guard<std::mutex> lock(snapshot_mutex);
+        // Object ID > 0: actual snapshot value, save to local disk
+        snap_mgr->saveSnapshotObject(s, obj_id, data);
+    }
+    LOG_INFO(log, "Save logical snapshot , object id {}, is_first_obj {}, is_last_obj {}", obj_id, is_first_obj, is_last_obj);
+    obj_id++;
+}
+
+bool NuRaftStateMachine::existSnapshotObject(snapshot & s, ulong obj_id) const
+{
+    return snap_mgr->existSnapshotObject(s, obj_id);
+}
+
+bool NuRaftStateMachine::apply_snapshot(snapshot & s)
+{
+    /// The invoker is from NuRaft, we should reset the state machine
+    LOG_INFO(log, "Reset state machine.");
+    reset();
+
+    return applySnapshotImpl(s);
+}
+
+bool NuRaftStateMachine::applySnapshotImpl(snapshot & s)
+{
+    LOG_INFO(log, "Applying snapshot term {}, last log index {}, size {}", s.get_last_log_term(), s.get_last_log_idx(), s.size());
+    std::lock_guard lock(snapshot_mutex);
+    bool succeed = snap_mgr->parseSnapshot(s, store);
+    if (succeed)
+    {
+        last_committed_idx = s.get_last_log_idx();
+        LOG_INFO(log, "Applied snapshot, now the last log index is {}", last_committed_idx);
+    }
+    return succeed;
+}
+
+void NuRaftStateMachine::replayLogs(ptr<log_store> log_store_, uint64_t from, uint64_t to)
+{
+    if (!log_store_)
+    {
+        LOG_WARNING(log, "There is no log_store, skip to replay logs.");
+        return;
+    }
+
+    ulong first_index_in_store = log_store_->start_index();
+    ulong last_index_in_store = log_store_->next_slot() - 1;
+
+    if (last_index_in_store == 0)
+    {
+        LOG_WARNING(log, "Log store is empty, skip to replay logs.");
+        return;
+    }
+
+    if (from > last_index_in_store)
+        throw Exception(
+            ErrorCodes::STALE_LOG,
+            "Logs in log store is stale. Last log index in log store is {} and snapshot last log index is {}. If the snapshot is copied "
+            "from another server, please clean the logs to start the server.",
+            last_index_in_store,
+            from);
+
+    if (from < first_index_in_store)
+        throw Exception(ErrorCodes::GAP_BETWEEN_SNAPSHOT_AND_LOG, "There is log gap between snapshot and log store, {} / {}", from, first_index_in_store);
+
+    if (to < last_index_in_store)
+    {
+        LOG_WARNING(log, "The last log index in log store is {} which is lower than 'to' {}, adjust to it.", last_index_in_store, to);
+        last_index_in_store = to;
+    }
+
+    /// [ batch_start_index, batch_end_index )
+    std::atomic<ulong> batch_start_index = from;
+    std::atomic<ulong> batch_end_index = 0;
+
+    ThreadSafeQueue<ReplayLogBatch> log_queue;
+
+    /// Loading and applying asynchronously
+    auto load_thread = ThreadFromGlobalPool(
+        [last_index_in_store, &log_queue, &batch_start_index, &batch_end_index, &log_store_]
+        {
+            Poco::Logger * thread_log = &(Poco::Logger::get("LoadLogThread"));
+            while (batch_start_index < last_index_in_store)
+            {
+                while (log_queue.size() > 10)
+                {
+                    LOG_DEBUG(thread_log, "Sleep 100ms to wait for applying log");
+                    usleep(100000);
+                }
+
+                /// 0.3 * 10000 = 3M
+                batch_end_index = batch_start_index + 10000;
+                if (batch_end_index > last_index_in_store + 1)
+                    batch_end_index = last_index_in_store + 1;
+
+                LOG_INFO(thread_log, "Begin to load batch [{} , {})", batch_start_index, batch_end_index);
+
+                ReplayLogBatch batch;
+                batch.log_entries
+                    = dynamic_cast<NuRaftFileLogStore *>(log_store_.get())->log_entries_version_ext(batch_start_index, batch_end_index, 0);
+
+                batch.batch_start_index = batch_start_index;
+                batch.batch_end_index = batch_end_index;
+                batch.requests = cs_new<std::vector<ptr<RequestForSession>>>();
+
+                for (auto & entry_with_version : *batch.log_entries)
+                {
+                    if (entry_with_version.entry->get_val_type() != nuraft::log_val_type::app_log)
+                    {
+                        LOG_DEBUG(thread_log, "Found non app nuraft log(type {}), ignore it", entry_with_version.entry->get_val_type());
+                        batch.requests->push_back(nullptr);
+                    }
+                    else
+                    {
+                        /// user requests
+                        auto request = deserializeKeeperRequest(entry_with_version.entry->get_buf());
+                        batch.requests->push_back(request);
+                    }
+                }
+
+                LOG_INFO(thread_log, "Finish to load batch [{}, {})", batch_start_index, batch_end_index);
+                log_queue.push(batch);
+                batch_start_index.store(batch_end_index);
+            }
+        });
+
+    /// Apply loaded logs
+    while (!log_queue.empty() || batch_start_index < last_index_in_store)
+    {
+        while (log_queue.empty() && batch_start_index != last_index_in_store)
+        {
+            LOG_DEBUG(log, "Sleep 100ms to wait for log loading");
+            usleep(100000);
+        }
+
+        ReplayLogBatch batch;
+        log_queue.peek(batch);
+
+        if (batch.log_entries == nullptr)
+        {
+            LOG_DEBUG(log, "log vector is null");
+            break;
+        }
+
+        for (size_t i = 0; i < batch.log_entries->size(); ++i)
+        {
+            ulong log_index = batch.batch_start_index + i;
+            auto & entry_with_version = (*batch.log_entries)[i];
+
+            if (entry_with_version.entry->get_val_type() != nuraft::log_val_type::app_log)
+                continue;
+
+            auto & request = (*batch.requests)[i];
+            LOG_TRACE(log, "Replaying log {}, request {}", log_index, request->toString());
+
+            store.processRequest(responses_queue, *request, {}, true, true);
+
+            if (!isNewSessionRequest(request->request->getOpNum()) && request->session_id > store.getSessionIDCounter())
+            {
+                /// We may receive an error session id from client, and we just ignore it.
+                LOG_WARNING(
+                    log,
+                    "Storage's session_id_counter {} must bigger than the session id {} of log.",
+                    toHexString(store.getSessionIDCounter()),
+                    toHexString(request->session_id));
+            }
+        }
+
+        log_queue.pop();
+        last_committed_idx = batch.batch_end_index - 1;
+
+        LOG_INFO(log, "Replayed log batch [{}, {})", batch.batch_start_index, batch.batch_end_index);
+    }
+
+    load_thread.join();
+
+    LOG_INFO(
+        log,
+        "Replay done, node count {}, session count {}, ephemeral nodes {}, watch count {}",
+        getNodesCount(),
+        store.getSessionCount(),
+        getTotalEphemeralNodesCount(),
+        getTotalWatchesCount());
+}
+
+void NuRaftStateMachine::free_user_snp_ctx(void *& user_snp_ctx)
+{
+    /// In this example, `read_logical_snp_obj` doesn't create
+    /// `user_snp_ctx`. Nothing to do in this function.
+    if (user_snp_ctx != nullptr)
+    {
+        free(user_snp_ctx);
+        user_snp_ctx = nullptr;
+    }
+}
+
+ptr<snapshot> NuRaftStateMachine::last_snapshot()
+{
+    std::lock_guard lock(snapshot_mutex);
+    return snap_mgr->lastSnapshot();
+}
+
+bool NuRaftStateMachine::exists(const String & path)
+{
+    return (store.getNode(path) != nullptr);
+}
+
+KeeperNode & NuRaftStateMachine::getNode(const String & path)
+{
+    auto node = store.getNode(path);
+    if (node != nullptr)
+    {
+        return *node.get();
+    }
+    return default_node;
+}
+
+void NuRaftStateMachine::reset()
+{
+    {
+        std::lock_guard lock(snapshot_mutex);
+        in_snapshot = false;
+    }
+    store.reset();
+    last_committed_idx = 0;
+    {
+        std::lock_guard lock(new_session_id_callback_mutex);
+        new_session_id_callback.clear();
+    }
+}
+
+
+std::vector<int64_t> NuRaftStateMachine::getDeadSessions() const
 {
     return store.getDeadSessions();
 }
@@ -348,405 +594,6 @@ uint64_t NuRaftStateMachine::getApproximateDataSize() const
 bool NuRaftStateMachine::containsSession(int64_t session_id) const
 {
     return store.containsSession(session_id);
-}
-
-void NuRaftStateMachine::shutdown()
-{
-    if (shutdown_called)
-        return;
-
-    shutdown_called = true;
-    LOG_INFO(log, "Shutting down state machine");
-
-    store.finalize();
-    committed_log_manager->shutDown();
-    snap_thread.join();
-    LOG_INFO(log, "State machine shut down done!");
-}
-
-bool NuRaftStateMachine::chk_create_snapshot()
-{
-    Poco::Timestamp now;
-    return !in_snapshot && now > last_snapshot_time + snapshot_creating_interval;
-}
-
-void NuRaftStateMachine::create_snapshot(snapshot & s, async_result<bool>::handler_type & when_done)
-{
-    size_t wait_times = 0;
-    while (request_processor && request_processor->commitQueueSize() != 0)
-    {
-        /// wait commit queue empty
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        if (++wait_times % 1000 == 0)
-        {
-            LOG_WARNING(log, "Wait commit queue to empty");
-        }
-    }
-
-    in_snapshot = true;
-    snap_start_time = Poco::Timestamp().epochMicroseconds() / 1000;
-
-    LOG_INFO(log, "Creating snapshot last_log_term {}, last_log_idx {}", s.get_last_log_term(), s.get_last_log_idx());
-
-    if (!raft_settings->async_snapshot)
-    {
-        create_snapshot(s, store.getZxid(), store.getSessionIDCounter());
-        ptr<std::exception> except(nullptr);
-        bool ret = true;
-        when_done(ret, except);
-
-        Metrics::getMetrics().snap_count->add(1);
-        Metrics::getMetrics().snap_time_ms->add(Poco::Timestamp().epochMicroseconds() / 1000 - snap_start_time);
-
-        last_snapshot_time = Poco::Timestamp().epochMicroseconds();
-        in_snapshot = false;
-
-        LOG_INFO(log, "Created snapshot, time cost {} ms", Poco::Timestamp().epochMicroseconds() / 1000 - snap_start_time);
-    }
-    else
-    {
-        /// Need make a copy of s
-        ptr<buffer> snp_buf = s.serialize();
-        auto snap_copy = snapshot::deserialize(*snp_buf);
-        snap_task = std::make_shared<SnapTask>(snap_copy, store, when_done);
-        snap_task_ready = true;
-
-        LOG_INFO(log, "Scheduling asynchronous creating snapshot task, time cost {} ms", Poco::Timestamp().epochMicroseconds() / 1000 - snap_start_time);
-    }
-}
-
-void NuRaftStateMachine::create_snapshot(snapshot & s, int64_t next_zxid, int64_t next_session_id)
-{
-    std::lock_guard<std::mutex> lock(snapshot_mutex);
-    snap_mgr->createSnapshot(s, store, next_zxid, next_session_id);
-    snap_mgr->removeSnapshots();
-}
-
-void NuRaftStateMachine::create_snapshot_async(SnapTask & s)
-{
-    std::lock_guard<std::mutex> lock(snapshot_mutex);
-    snap_mgr->createSnapshotAsync(s);
-    snap_mgr->removeSnapshots();
-}
-
-void NuRaftStateMachine::save_snapshot_data(snapshot &, const ulong, buffer &)
-{
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "method is deprecated");
-}
-
-int NuRaftStateMachine::read_snapshot_data(snapshot &, const ulong, buffer &)
-{
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "method is deprecated");
-}
-
-int NuRaftStateMachine::read_logical_snp_obj(snapshot & s, void *& user_snp_ctx, ulong obj_id, ptr<buffer> & data_out, bool & is_last_obj)
-{
-    std::lock_guard<std::mutex> lock(snapshot_mutex);
-    if (!snap_mgr->existSnapshot(s))
-    {
-        data_out = nullptr;
-        is_last_obj = true;
-        LOG_INFO(log, "Can't find snapshot by last_log_idx {}, object id {}", s.get_last_log_idx(), obj_id);
-        return 0;
-    }
-
-    if (obj_id == 0)
-    {
-        // Object ID == 0: first object
-        data_out = buffer::alloc(sizeof(UInt32));
-        buffer_serializer bs(data_out);
-        bs.put_i32(0);
-        is_last_obj = false;
-        LOG_INFO(log, "Read snapshot object, last_log_idx {}, object id {}, is_last {}", s.get_last_log_idx(), obj_id, false);
-        return 0;
-    }
-
-    // Object ID > 0: second object, put actual value.
-    snap_mgr->loadSnapshotObject(s, obj_id, data_out);
-    is_last_obj = !(snap_mgr->existSnapshotObject(s, obj_id + 1));
-
-    LOG_INFO(log, "Read snapshot object, last_log_idx {}, object id {}, is_last {}", s.get_last_log_idx(), obj_id, is_last_obj);
-    user_snp_ctx = nullptr;
-
-    return 0;
-}
-
-void NuRaftStateMachine::save_logical_snp_obj(snapshot & s, ulong & obj_id, buffer & data, bool is_first_obj, bool is_last_obj)
-{
-    if (obj_id == 0)
-    {
-        // Object ID == 0: it contains dummy value, create snapshot context.
-        snap_mgr->receiveSnapshotMeta(s);
-    }
-    else
-    {
-        std::lock_guard<std::mutex> lock(snapshot_mutex);
-        // Object ID > 0: actual snapshot value, save to local disk
-        snap_mgr->saveSnapshotObject(s, obj_id, data);
-    }
-    LOG_INFO(log, "Save logical snapshot , object id {}, is_first_obj {}, is_last_obj {}", obj_id, is_first_obj, is_last_obj);
-    obj_id++;
-}
-
-bool NuRaftStateMachine::existSnapshotObject(snapshot & s, ulong obj_id)
-{
-    return snap_mgr->existSnapshotObject(s, obj_id);
-}
-
-bool NuRaftStateMachine::apply_snapshot(snapshot & s)
-{
-    /// The invoker is from NuRaft, we should reset the state machine
-    LOG_INFO(log, "Reset state machine.");
-    reset();
-
-    return applySnapshotImpl(s);
-}
-
-bool NuRaftStateMachine::applySnapshotImpl(snapshot & s)
-{
-    LOG_INFO(log, "Applying snapshot term {}, last log index {}, size {}", s.get_last_log_term(), s.get_last_log_idx(), s.size());
-    std::lock_guard<std::mutex> lock(snapshot_mutex);
-    bool succeed = snap_mgr->parseSnapshot(s, store);
-    if (succeed)
-    {
-        last_committed_idx = s.get_last_log_idx();
-        LOG_INFO(log, "Applied snapshot, now the last log index is {}", last_committed_idx);
-    }
-    return succeed;
-}
-
-void NuRaftStateMachine::replayLogs(ptr<log_store> log_store_, uint64_t from, uint64_t to)
-{
-    if (!log_store_)
-    {
-        LOG_WARNING(log, "There is no log_store, skip to replay logs.");
-        return;
-    }
-
-    ulong first_index_in_store = log_store_->start_index();
-    ulong last_index_in_store = log_store_->next_slot() - 1;
-
-    if (last_index_in_store == 0)
-    {
-        LOG_WARNING(log, "Log store is empty, skip to replay logs.");
-        return;
-    }
-
-    if (from > last_index_in_store)
-        throw Exception(
-            ErrorCodes::STALE_LOG,
-            "Logs in log store is stale. Last log index in log store is {} and snapshot last log index is {}. If the snapshot is copied "
-            "from another server, please clean the logs to start the server.",
-            last_index_in_store,
-            from);
-
-    if (from < first_index_in_store)
-        throw Exception(ErrorCodes::GAP_BETWEEN_SNAPSHOT_AND_LOG, "There is log gap between snapshot and log store, {} / {}", from, first_index_in_store);
-
-    if (to < last_index_in_store)
-    {
-        LOG_WARNING(log, "The last log index in log store is {} which is lower than 'to' {}, adjust to it.", last_index_in_store, to);
-        last_index_in_store = to;
-    }
-
-    /// [ batch_start_index, batch_end_index )
-    std::atomic<ulong> batch_start_index = from;
-    std::atomic<ulong> batch_end_index = 0;
-
-    ThreadSafeQueue<ReplayLogBatch> log_queue;
-
-    /// Loading and applying asynchronously
-    auto load_thread = ThreadFromGlobalPool(
-        [this, last_index_in_store, &log_queue, &batch_start_index, &batch_end_index, &log_store_]
-        {
-            Poco::Logger * thread_log = &(Poco::Logger::get("LoadLogThread"));
-            while (batch_start_index < last_index_in_store)
-            {
-                while (log_queue.size() > 10)
-                {
-                    LOG_DEBUG(thread_log, "Sleep 100ms to wait for applying log");
-                    usleep(100000);
-                }
-
-                /// 0.3 * 10000 = 3M
-                batch_end_index = batch_start_index + 10000;
-                if (batch_end_index > last_index_in_store + 1)
-                    batch_end_index = last_index_in_store + 1;
-
-                LOG_INFO(thread_log, "Begin to load batch [{} , {})", batch_start_index, batch_end_index);
-
-                ReplayLogBatch batch;
-                batch.log_vec
-                    = dynamic_cast<NuRaftFileLogStore *>(log_store_.get())->log_entries_version_ext(batch_start_index, batch_end_index, 0);
-
-                batch.batch_start_index = batch_start_index;
-                batch.batch_end_index = batch_end_index;
-                batch.request_vec = cs_new<std::vector<ptr<RequestForSession>>>();
-
-                for (auto entry : *(batch.log_vec))
-                {
-                    if (entry.entry->get_val_type() != nuraft::log_val_type::app_log)
-                    {
-                        LOG_DEBUG(thread_log, "Found non app log(type {}), ignore it", entry.entry->get_val_type());
-                        batch.request_vec->push_back(nullptr);
-                    }
-                    else if (isNewSessionRequest(entry.entry->get_buf()))
-                    {
-                        batch.request_vec->push_back(nullptr);
-                    }
-                    else if (isUpdateSessionRequest(entry.entry->get_buf()))
-                    {
-                        batch.request_vec->push_back(nullptr);
-                    }
-                    else
-                    {
-                        /// user requests
-                        ptr<RequestForSession> ptr_request = createRequestSession(entry.entry);
-                        batch.request_vec->push_back(ptr_request);
-                    }
-                }
-
-                LOG_INFO(thread_log, "Finish to load batch [{}, {})", batch_start_index, batch_end_index);
-                log_queue.push(batch);
-                batch_start_index.store(batch_end_index);
-            }
-        });
-
-    /// Apply loaded logs
-    while (!log_queue.empty() || batch_start_index < last_index_in_store)
-    {
-        while (log_queue.empty() && batch_start_index != last_index_in_store)
-        {
-            LOG_DEBUG(log, "Sleep 100ms to wait for log loading");
-            usleep(100000);
-        }
-
-        ReplayLogBatch batch;
-        log_queue.peek(batch);
-
-        if (batch.log_vec == nullptr)
-        {
-            LOG_DEBUG(log, "log vector is null");
-            break;
-        }
-
-        for (size_t i = 0; i < batch.log_vec->size(); ++i)
-        {
-            ulong log_index = batch.batch_start_index + i;
-            auto entry = (*batch.log_vec)[i];
-            if (entry.entry->get_val_type() != nuraft::log_val_type::app_log)
-                continue;
-
-            /// Compatible with old NewSessionRequest log_entry.
-            if (isNewSessionRequest(entry.entry->get_buf()))
-            {
-                /// replay session
-                int64_t session_timeout_ms = entry.entry->get_buf().get_ulong();
-                int64_t session_id = store.getSessionID(session_timeout_ms);
-                LOG_TRACE(log, "Replay log create session {} with timeout {} from log", toHexString(session_id), session_timeout_ms);
-            }
-            /// Compatible with old UpdateSessionRequest log_entry.
-            else if (isUpdateSessionRequest(entry.entry->get_buf()))
-            {
-                /// replay update session
-                nuraft::buffer_serializer data_serializer(entry.entry->get_buf());
-                int64_t session_id = data_serializer.get_i64();
-                int64_t session_timeout_ms = data_serializer.get_i64();
-
-                store.updateSessionTimeout(session_id, session_timeout_ms);
-                LOG_TRACE(log, "Replay log update session {} with timeout {}", toHexString(session_id), session_timeout_ms);
-            }
-            else
-            {
-                /// replay user requests
-                auto & request = (*batch.request_vec)[i];
-                LOG_TRACE(log, "Replay log {}, request {}", log_index, request->toString());
-                store.processRequest(responses_queue, *request, {}, true, true);
-                if (!RK::isNewSessionRequest(request->request->getOpNum()) && request->session_id > store.getSessionIDCounter())
-                {
-                    /// We may receive an error session id from client, and we just ignore it.
-                    LOG_WARNING(
-                        log,
-                        "Storage's session_id_counter {} must bigger than the session id {} of log.",
-                        toHexString(store.getSessionIDCounter()),
-                        toHexString(request->session_id));
-                }
-            }
-        }
-
-        log_queue.pop();
-        last_committed_idx = batch.batch_end_index - 1;
-
-        LOG_INFO(log, "Replayed log batch [{}, {})", batch.batch_start_index, batch.batch_end_index);
-    }
-
-    load_thread.join();
-
-    LOG_INFO(
-        log,
-        "Replay done, node count {}, session count {}, ephemeral nodes {}, watch count {}",
-        getNodesCount(),
-        store.getSessionCount(),
-        getTotalEphemeralNodesCount(),
-        getTotalWatchesCount());
-}
-
-void NuRaftStateMachine::free_user_snp_ctx(void *& user_snp_ctx)
-{
-    /// In this example, `read_logical_snp_obj` doesn't create
-    /// `user_snp_ctx`. Nothing to do in this function.
-    if (user_snp_ctx != nullptr)
-    {
-        free(user_snp_ctx);
-        user_snp_ctx = nullptr;
-    }
-}
-
-ptr<snapshot> NuRaftStateMachine::last_snapshot()
-{
-    /// Just return the latest snapshot.
-    std::lock_guard<std::mutex> lock(snapshot_mutex);
-    LOG_INFO(log, "last_snapshot invoke");
-    return snap_mgr->lastSnapshot();
-}
-
-bool NuRaftStateMachine::exists(const String & path)
-{
-    return (store.getNode(path) != nullptr);
-}
-
-KeeperNode & NuRaftStateMachine::getNode(const String & path)
-{
-    auto node_ptr = store.getNode(path);
-    if (node_ptr != nullptr)
-    {
-        return *node_ptr.get();
-    }
-    return default_node;
-}
-
-bool NuRaftStateMachine::isNewSessionRequest(nuraft::buffer & data)
-{
-    return data.size() == sizeof(int64);
-}
-
-bool NuRaftStateMachine::isUpdateSessionRequest(nuraft::buffer & data)
-{
-    return data.size() == sizeof(int64) + sizeof(int64);
-}
-
-void NuRaftStateMachine::reset()
-{
-    {
-        std::lock_guard lock(snapshot_mutex);
-        in_snapshot = false;
-    }
-    store.reset();
-    last_committed_idx = 0;
-    {
-        std::lock_guard lock(new_session_id_callback_mutex);
-        new_session_id_callback.clear();
-    }
 }
 
 }

--- a/src/Service/RequestForwarder.cpp
+++ b/src/Service/RequestForwarder.cpp
@@ -120,7 +120,7 @@ void RequestForwarder::runSend(RunnerId runner_id)
             }
 
             session_sync_time_watch.restart();
-            session_sync_idx++;
+            ++session_sync_idx;
         }
     }
 }

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -82,7 +82,6 @@ void RaftSettings::loadFromConfig(const String & config_elem, const Poco::Util::
 
         String log_level = config.getString(get_key("raft_logs_level"), "information");
         raft_logs_level = parseNuRaftLogLevel(log_level);
-        rotate_log_storage_interval = config.getUInt(get_key("rotate_log_storage_interval"), 100000);
         nuraft_thread_size = config.getUInt(get_key("nuraft_thread_size"), getNumberOfPhysicalCPUCores());
         fresh_log_gap = config.getUInt(get_key("fresh_log_gap"), 200);
         configuration_change_tries_count = config.getUInt(get_key("configuration_change_tries_count"), 30);
@@ -117,7 +116,6 @@ RaftSettingsPtr RaftSettings::getDefault()
     settings->startup_timeout = 6000000;
 
     settings->raft_logs_level = NuRaftLogLevel::RAFT_LOG_INFORMATION;
-    settings->rotate_log_storage_interval = 100000;
     settings->nuraft_thread_size = getNumberOfPhysicalCPUCores();
     settings->fresh_log_gap = 200;
     settings->configuration_change_tries_count = 30;
@@ -214,8 +212,6 @@ void Settings::dump(WriteBufferFromOwnString & buf) const
     writeText("raft_logs_level=", buf);
     writeText(nuRaftLogLevelToString(raft_settings->raft_logs_level), buf);
     buf.write('\n');
-    writeText("rotate_log_storage_interval=", buf);
-    write_int(raft_settings->rotate_log_storage_interval);
 
     writeText("log_fsync_mode=", buf);
     writeText(FsyncModeNS::toString(raft_settings->log_fsync_mode), buf);

--- a/src/Service/Settings.h
+++ b/src/Service/Settings.h
@@ -98,8 +98,6 @@ struct RaftSettings
     UInt64 startup_timeout;
     /// Log internal RAFT logs into main server log level. Valid values: 'trace', 'debug', 'information', 'warning', 'error', 'fatal'
     NuRaftLogLevel raft_logs_level;
-    /// How many records will be stored in one log storage file. TODO remove
-    UInt64 rotate_log_storage_interval;
     /// NuRaft thread pool size
     UInt64 nuraft_thread_size;
     /// When node became fresh

--- a/src/Service/SnapshotCommon.cpp
+++ b/src/Service/SnapshotCommon.cpp
@@ -3,6 +3,7 @@
 #include <Common/Exception.h>
 #include <Common/IO/WriteHelpers.h>
 
+#include <Service/Crc32.h>
 #include <Service/KeeperUtils.h>
 #include <Service/ReadBufferFromNuRaftBuffer.h>
 #include <Service/SnapshotCommon.h>

--- a/src/Service/tests/gtest_raft_state_machine.cpp
+++ b/src/Service/tests/gtest_raft_state_machine.cpp
@@ -42,10 +42,10 @@ TEST(RaftStateMachine, serializeAndParse)
     session_request.create_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 
     ptr<buffer> buf = serializeKeeperRequest(session_request);
-    RequestForSession session_request_2 = deserializeKeeperRequest(*(buf.get()));
-    if (session_request_2.request->getOpNum() == OpNum::Create)
+    ptr<RequestForSession> session_request_2 = deserializeKeeperRequest(*(buf.get()));
+    if (session_request_2->request->getOpNum() == OpNum::Create)
     {
-        ZooKeeperCreateRequest * request_2 = static_cast<ZooKeeperCreateRequest *>(session_request_2.request.get());
+        ZooKeeperCreateRequest * request_2 = static_cast<ZooKeeperCreateRequest *>(session_request_2->request.get());
         ASSERT_EQ(request_2->path, request->path);
         ASSERT_EQ(request_2->data, request->data);
     }

--- a/src/ZooKeeper/ZooKeeperCommon.h
+++ b/src/ZooKeeper/ZooKeeperCommon.h
@@ -1,25 +1,19 @@
 #pragma once
 
-#include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
-#include <mutex>
-#include <optional>
-#include <thread>
 #include <unordered_map>
 #include <vector>
 
-#include "IKeeper.h"
-#include "ZooKeeperConstants.h"
 #include <Common/IO/ReadBuffer.h>
 #include <Common/IO/WriteBuffer.h>
 #include <Common/IO/WriteHelpers.h>
 #include <boost/noncopyable.hpp>
-#include <Common/IO//Operators.h>
-#include <Common/IO/ReadBufferFromString.h>
+
+#include <ZooKeeper/IKeeper.h>
+#include <ZooKeeper/ZooKeeperConstants.h>
 
 
 namespace Coordination

--- a/tests/integration/test_four_word_command/test.py
+++ b/tests/integration/test_four_word_command/test.py
@@ -307,7 +307,6 @@ def test_cmd_conf(started_cluster):
         assert result["startup_timeout"] == "6000000"
 
         assert result["raft_logs_level"] == "debug"
-        assert result["rotate_log_storage_interval"] == "100000"
         assert result["log_fsync_mode"] == "fsync_parallel"
 
         assert result["log_fsync_interval"] == "1000"


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
Fix #351,  Fix #266

### Change log:
<!-- (Please describe the changes you have made in details. -->

1. Remove raftkeeper 1.0 only code
2. Use steady_lock instead of system_lock