### PR TITLE
Fix clang 20 build error: no-switch-default-label

### DIFF
--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -29,7 +29,7 @@ else ()
     target_compile_definitions(common PUBLIC WITH_COVERAGE=0)
 endif ()
 
-target_compile_options(common PUBLIC -Wno-implicit-const-int-float-conversion -Wno-reserved-identifier)
+target_compile_options(common PUBLIC -Wno-implicit-const-int-float-conversion -Wno-reserved-identifier -Wno-switch-default)
 
 if (USE_INTERNAL_CCTZ)
     set_source_files_properties(DateLUTImpl.cpp PROPERTIES COMPILE_DEFINITIONS USE_INTERNAL_CCTZ)


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #373

### Change log:
<!-- (Please describe the changes you have made in details. -->
- Ignore no-switch-default-label warning
