### PR TITLE
feat: zstd-compressed snapshots (V3)

### DIFF
--- a/docs/zstd-snapshot-benchmark.md
+++ b/docs/zstd-snapshot-benchmark.md
@@ -1,0 +1,109 @@
+# Zstd snapshot compression benchmark
+
+## Design
+
+**Goal:** quantify what V3 (zstd) snapshots buy over V2 (raw) on the two axes
+that matter for snapshots — **on-disk / on-wire size** (snapshots are shipped
+to lagging followers on catch-up) and **create/load wall time** (does
+compressing slow down snapshotting or recovery?).
+
+Harness: `src/Service/tests/gtest_snapshot_zstd_bench.cpp`
+(`SnapshotZstdBench.DISABLED_V2vsV3`). It exercises the real snapshot path —
+`KeeperSnapshotManager::createSnapshot(..., version)` and `parseSnapshot(...)` —
+so it measures the same code production uses, not a synthetic codec loop.
+
+### Dimensions
+
+| Dimension | Values | Why |
+|-----------|--------|-----|
+| Store shape | 100K×128B, 100K×0.3KB, 50K×1KB | small flags → typical ZK data → large values |
+| Version | V2 (raw), V3 (zstd level 3) | the on/off comparison |
+
+Level is fixed at 3 — reuses `ZstdLogCodec`, whose level was already tuned in
+the [log benchmark](zstd-level-benchmark.md); no reason to expect a different
+sweet spot for snapshot bodies.
+
+### Data shape
+
+75% repetitive (JSON-like), 25% pseudo-random, same generator as the log
+benchmark. Pure-random defeats compression; pure-repetition is unrealistically
+easy. Real ZK trees skew *more* repetitive than this (shared path prefixes,
+templated values), so the ratios below are conservative-to-optimistic
+depending on workload.
+
+### Metrics
+
+| Metric | Meaning |
+|--------|---------|
+| `create_ms` | wall time to serialize the whole store to snapshot objects |
+| `load_ms` | wall time to parse the snapshot back into a fresh store |
+| `disk_MB` | total on-disk size of all snapshot objects |
+| `ratio` | V2 disk size / V3 disk size (higher = better) |
+
+## Results
+
+1M-ish nodes, single run, RelWithDebInfo, no sanitizer:
+
+```
+version       nodes   create_ms    load_ms    disk_MB    ratio
+------------------------------------------------------------
+── 100K x 128B ──
+V2           100000       275.0       73.0      22.39     1.00
+V3           100000       237.0       59.0       2.00    11.17
+── 100K x 0.3KB ──
+V2           100000       354.0       96.0      40.29     1.00
+V3           100000       265.0       69.0       2.14    18.85
+── 50K x 1KB ──
+V2            50000       384.0       85.0      55.99     1.00
+V3            50000       194.0       62.0       1.14    48.93
+```
+
+## Analysis
+
+### V3 is smaller AND faster
+
+Unlike the log path (where per-entry compression cost is visible at large
+batches), snapshot V3 **wins on every axis**:
+
+- **Size: 11–49× smaller.** Snapshot bodies are batched (`SAVE_BATCH_SIZE`
+  nodes per zstd frame), so the compressor sees a large, highly-repetitive
+  window — far better than the log path's per-entry frames.
+- **Create: 14–49% faster.** Writing 2 MB instead of 56 MB through
+  `WriteBufferFromFile` (plus the final flush/fsync) saves more time than the
+  zstd CPU costs. The bigger the values, the bigger the win (1KB case: 384→194 ms).
+- **Load: 19–27% faster.** Reading + CRC-checking far fewer bytes off disk
+  outweighs decompression, same effect the log read path showed.
+
+### Why the ratio climbs with value size
+
+At 128B most of a node's on-disk footprint is fixed overhead (path, stat
+struct, acl_id) that compresses modestly; at 1KB the compressible value
+dominates, so the ratio jumps to ~49×. The absolute *bytes saved* grows even
+faster (56 MB → 1.1 MB).
+
+### Caveats
+
+- Ratios are workload-dependent. This data is deliberately compressible;
+  incompressible blobs (already-compressed payloads, encryption) would
+  approach 1.0 — but zstd's frame overhead is tiny, so V3 is never
+  meaningfully *worse* on size, and still wins on create time via fewer bytes
+  written.
+- Single-run wall times carry ±10% noise; the size ratios are deterministic.
+
+## Recommendation
+
+- **Enable `snapshot_compression=zstd` wherever snapshots are large or shipped
+  between nodes.** It reduces disk, reduces follower catch-up transfer, and is
+  faster to write and read.
+- Kept **opt-in / default off** only for rolling-upgrade safety (a V3 snapshot
+  can't be read by a pre-V3 binary). Once every node runs a V3-capable binary,
+  turn it on cluster-wide.
+
+## Reproduce
+
+```bash
+cmake -B build   # only needed once, to pick up the new gtest file
+ninja -C build rk_unit_tests
+./build/src/rk_unit_tests --gtest_also_run_disabled_tests \
+    --gtest_filter='SnapshotZstdBench.*' 2>&1
+```

--- a/src/Service/NuRaftLogSnapshot.cpp
+++ b/src/Service/NuRaftLogSnapshot.cpp
@@ -18,6 +18,7 @@
 #include <Service/NuRaftLogSnapshot.h>
 #include <Service/ReadBufferFromNuRaftBuffer.h>
 #include <Service/WriteBufferFromNuraftBuffer.h>
+#include <Service/ZstdLogCodec.h>
 #include <ZooKeeper/ZooKeeperIO.h>
 
 
@@ -58,7 +59,7 @@ size_t KeeperSnapshotStore::serializeDataTreeV2(KeeperStore & storage)
     uint32_t checksum = 0;
 
     serializeNodeV2(out, batch, storage, "/", processed, checksum);
-    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
     checksum = new_checksum;
 
     writeTailAndClose(out, checksum);
@@ -73,7 +74,7 @@ size_t KeeperSnapshotStore::serializeDataTreeAsync(SnapTask & snap_task) const
     ptr<SnapshotBatchBody> batch;
 
     auto checksum = serializeNodeAsync(out, batch, *snap_task.buckets_nodes);
-    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
     checksum = new_checksum;
 
     writeTailAndClose(out, checksum);
@@ -106,7 +107,7 @@ void KeeperSnapshotStore::serializeNodeV2(
         if (obj_id != 0)
         {
             /// flush last batch data
-            auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+            auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
             checksum = new_checksum;
 
             /// close current object file
@@ -129,7 +130,7 @@ void KeeperSnapshotStore::serializeNodeV2(
         if (processed != 0)
         {
             /// flush data in batch to file
-            auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+            auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
             checksum = new_checksum;
         }
         else
@@ -170,7 +171,7 @@ uint32_t KeeperSnapshotStore::serializeNodeAsync(
                 if (obj_id != 0)
                 {
                     /// flush last batch data
-                    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+                    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
                     checksum = new_checksum;
 
                     /// close current object file
@@ -193,7 +194,7 @@ uint32_t KeeperSnapshotStore::serializeNodeAsync(
                 if (processed != 0)
                 {
                     /// flush data in batch to file
-                    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+                    auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
                     checksum = new_checksum;
                 }
                 else
@@ -515,6 +516,12 @@ void KeeperSnapshotStore::parseObject(KeeperStore & store, String obj_path, Buck
         if (!verifyCRC32(body_buf, header.data_length, header.data_crc))
         {
             throwFromErrno("Can't read snapshot object file " + obj_path + ", batch crc not match.", ErrorCodes::CORRUPTED_SNAPSHOT);
+        }
+
+        if (version_from_obj >= SnapshotVersion::V3)
+        {
+            auto decompressed = ZstdLogCodec::decompress(body_string.data(), body_string.size());
+            body_string.assign(reinterpret_cast<const char *>(decompressed->data_begin()), decompressed->size());
         }
 
         parseBatchBodyV2(store, body_string, buckets_edges, bucket_nodes, version_from_obj);

--- a/src/Service/NuRaftLogSnapshot.cpp
+++ b/src/Service/NuRaftLogSnapshot.cpp
@@ -471,7 +471,7 @@ void KeeperSnapshotStore::parseObject(KeeperStore & store, String obj_path, Buck
             snap_fs->read(buf, sizeof(uint8_t));
             read_size += 1;
             LOG_DEBUG(log, "Got snapshot file header with version {}", toString(version_from_obj));
-            if (version_from_obj > CURRENT_SNAPSHOT_VERSION)
+            if (version_from_obj > MAX_SNAPSHOT_VERSION)
                 throw Exception(ErrorCodes::UNKNOWN_FORMAT_VERSION, "Unsupported snapshot version {}", toString(version_from_obj));
         }
         else if (isSnapshotFileTail(magic))
@@ -520,8 +520,16 @@ void KeeperSnapshotStore::parseObject(KeeperStore & store, String obj_path, Buck
 
         if (version_from_obj >= SnapshotVersion::V3)
         {
-            auto decompressed = ZstdLogCodec::decompress(body_string.data(), body_string.size());
-            body_string.assign(reinterpret_cast<const char *>(decompressed->data_begin()), decompressed->size());
+            try
+            {
+                auto decompressed = ZstdLogCodec::decompress(body_string.data(), body_string.size());
+                body_string.assign(reinterpret_cast<const char *>(decompressed->data_begin()), decompressed->size());
+            }
+            catch (Exception & e)
+            {
+                e.addMessage("Can't decompress snapshot object " + obj_path);
+                throw;
+            }
         }
 
         parseBatchBodyV2(store, body_string, buckets_edges, bucket_nodes, version_from_obj);

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -317,14 +317,14 @@ public:
 
     size_t createSnapshotAsync(
         SnapTask & snap_task,
-        SnapshotVersion version = CURRENT_SNAPSHOT_VERSION);
+        SnapshotVersion version = SnapshotVersion::V2);
 
     size_t createSnapshot(
         snapshot & meta,
         KeeperStore & store,
         int64_t next_zxid = 0,
         int64_t next_session_id = 0,
-        SnapshotVersion version = CURRENT_SNAPSHOT_VERSION);
+        SnapshotVersion version = SnapshotVersion::V2);
 
     /// save snapshot meta, invoked when we receive an snapshot from leader.
     bool receiveSnapshotMeta(snapshot & meta);

--- a/src/Service/NuRaftLogSnapshot.h
+++ b/src/Service/NuRaftLogSnapshot.h
@@ -135,7 +135,7 @@ public:
         snapshot & meta,
         UInt32 max_object_node_size_ = MAX_OBJECT_NODE_SIZE,
         UInt32 save_batch_size_ = SAVE_BATCH_SIZE,
-        SnapshotVersion version_ = CURRENT_SNAPSHOT_VERSION)
+        SnapshotVersion version_ = SnapshotVersion::V2)
         : version(version_)
         , snap_dir(snap_dir_)
         , max_object_node_size(max_object_node_size_)

--- a/src/Service/NuRaftStateMachine.cpp
+++ b/src/Service/NuRaftStateMachine.cpp
@@ -308,7 +308,8 @@ void NuRaftStateMachine::create_snapshot(snapshot & s, async_result<bool>::handl
 void NuRaftStateMachine::create_snapshot(snapshot & s, int64_t next_zxid, int64_t next_session_id)
 {
     std::lock_guard lock(snapshot_mutex);
-    snap_mgr->createSnapshot(s, store, next_zxid, next_session_id);
+    auto version = raft_settings->snapshot_compression == "zstd" ? SnapshotVersion::V3 : SnapshotVersion::V2;
+    snap_mgr->createSnapshot(s, store, next_zxid, next_session_id, version);
     snap_mgr->removeSnapshots();
     compactLogStore();
 }
@@ -316,7 +317,8 @@ void NuRaftStateMachine::create_snapshot(snapshot & s, int64_t next_zxid, int64_
 void NuRaftStateMachine::create_snapshot_async(SnapTask & s)
 {
     std::lock_guard lock(snapshot_mutex);
-    snap_mgr->createSnapshotAsync(s);
+    auto version = raft_settings->snapshot_compression == "zstd" ? SnapshotVersion::V3 : SnapshotVersion::V2;
+    snap_mgr->createSnapshotAsync(s, version);
     snap_mgr->removeSnapshots();
     compactLogStore();
 }

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -95,6 +95,7 @@ void RaftSettings::loadFromConfig(const String & config_elem, const Poco::Util::
         log_fsync_interval = config.getUInt(get_key("log_fsync_interval"), 1000);
         max_log_segment_file_size = config.getUInt(get_key("max_log_segment_file_size"), 1073741824);
         log_compression = config.getString(get_key("log_compression"), "none");
+        snapshot_compression = config.getString(get_key("snapshot_compression"), "none");
         async_snapshot = config.getBool(get_key("async_snapshot"), true);
     }
     catch (Exception & e)
@@ -130,6 +131,7 @@ RaftSettingsPtr RaftSettings::getDefault()
     settings->log_fsync_interval = 1000;
     settings->max_log_segment_file_size = 1073741824;
     settings->log_compression = "none";
+    settings->snapshot_compression = "none";
     settings->log_fsync_mode = FsyncMode::FSYNC_PARALLEL;
     settings->async_snapshot = true;
 
@@ -241,6 +243,10 @@ void Settings::dump(WriteBufferFromOwnString & buf) const
 
     writeText("log_compression=", buf);
     writeText(raft_settings->log_compression, buf);
+    buf.write('\n');
+
+    writeText("snapshot_compression=", buf);
+    writeText(raft_settings->snapshot_compression, buf);
     buf.write('\n');
 
     writeText("nuraft_thread_size=", buf);

--- a/src/Service/Settings.cpp
+++ b/src/Service/Settings.cpp
@@ -97,6 +97,11 @@ void RaftSettings::loadFromConfig(const String & config_elem, const Poco::Util::
         log_compression = config.getString(get_key("log_compression"), "none");
         snapshot_compression = config.getString(get_key("snapshot_compression"), "none");
         async_snapshot = config.getBool(get_key("async_snapshot"), true);
+
+        if (log_compression != "none" && log_compression != "zstd")
+            LOG_WARNING(log, "Unknown log_compression '{}' — valid values are 'none' and 'zstd'. Falling back to no compression.", log_compression);
+        if (snapshot_compression != "none" && snapshot_compression != "zstd")
+            LOG_WARNING(log, "Unknown snapshot_compression '{}' — valid values are 'none' and 'zstd'. Falling back to no compression.", snapshot_compression);
     }
     catch (Exception & e)
     {

--- a/src/Service/Settings.h
+++ b/src/Service/Settings.h
@@ -114,6 +114,8 @@ struct RaftSettings
     UInt64 max_log_segment_file_size;
     /// Log entry codec: "none" or "zstd". Applies to newly written entries; readers auto-detect per-entry.
     String log_compression;
+    /// Snapshot codec: "none" (V2) or "zstd" (V3). Applies to newly written snapshots; readers auto-detect via version byte.
+    String snapshot_compression;
     /// Whether async snapshot
     bool async_snapshot;
 

--- a/src/Service/SnapshotCommon.cpp
+++ b/src/Service/SnapshotCommon.cpp
@@ -8,6 +8,7 @@
 #include <Service/ReadBufferFromNuRaftBuffer.h>
 #include <Service/SnapshotCommon.h>
 #include <Service/WriteBufferFromNuraftBuffer.h>
+#include <Service/ZstdLogCodec.h>
 #include <ZooKeeper/ZooKeeperIO.h>
 
 namespace RK
@@ -30,6 +31,8 @@ String toString(SnapshotVersion version)
             return "v1";
         case SnapshotVersion::V2:
             return "v2";
+        case SnapshotVersion::V3:
+            return "v3";
         case SnapshotVersion::UNKNOWN:
             return "unknown";
     }
@@ -153,12 +156,20 @@ ptr<KeeperNodeWithPath>parseKeeperNode(const String & buf, SnapshotVersion versi
 }
 
 
-std::pair<size_t, UInt32> saveBatchV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch)
+std::pair<size_t, UInt32> saveBatchV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch, SnapshotVersion version)
 {
     if (!batch)
         batch = cs_new<SnapshotBatchBody>();
 
     String str_buf = SnapshotBatchBody::serialize(*batch);
+
+    if (version >= SnapshotVersion::V3)
+    {
+        auto compressed = ZstdLogCodec::compress(str_buf.data(), str_buf.size());
+        if (!compressed)
+            throw Exception(ErrorCodes::CORRUPTED_SNAPSHOT, "Failed to zstd-compress snapshot batch");
+        str_buf.assign(reinterpret_cast<const char *>(compressed->data_begin()), compressed->size());
+    }
 
     SnapshotBatchHeader header;
     header.data_length = str_buf.size();
@@ -174,9 +185,9 @@ std::pair<size_t, UInt32> saveBatchV2(ptr<WriteBufferFromFile> & out, ptr<Snapsh
 }
 
 std::pair<size_t, UInt32>
-saveBatchAndUpdateCheckSumV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch, UInt32 checksum)
+saveBatchAndUpdateCheckSumV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch, UInt32 checksum, SnapshotVersion version)
 {
-    auto [save_size, data_crc] = saveBatchV2(out, batch);
+    auto [save_size, data_crc] = saveBatchV2(out, batch, version);
     /// rebuild batch
     batch = cs_new<SnapshotBatchBody>();
     return {save_size, updateCheckSum(checksum, data_crc)};
@@ -203,7 +214,7 @@ void serializeAclsV2(const NumToACLMap & acl_map, String path, UInt32 save_batch
             if (index != 0)
             {
                 /// write data in batch to file
-                auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+                auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
                 checksum = new_checksum;
             }
             batch = cs_new<SnapshotBatchBody>();
@@ -223,7 +234,7 @@ void serializeAclsV2(const NumToACLMap & acl_map, String path, UInt32 save_batch
     }
 
     /// flush the last acl batch
-    auto [_, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+    auto [_, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
     checksum = new_checksum;
 
     writeTailAndClose(out, checksum);
@@ -251,7 +262,7 @@ void serializeSessionsV2(SessionAndTimeout & session_and_timeout, SessionAndAuth
             if (index != 0)
             {
                 /// write data in batch to file
-                auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+                auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
                 checksum = new_checksum;
             }
             batch = cs_new<SnapshotBatchBody>();
@@ -276,7 +287,7 @@ void serializeSessionsV2(SessionAndTimeout & session_and_timeout, SessionAndAuth
     }
 
     /// flush the last batch
-    auto [_, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+    auto [_, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
     checksum = new_checksum;
     writeTailAndClose(out, checksum);
 }
@@ -302,7 +313,7 @@ void serializeMapV2(T & snap_map, UInt32 save_batch_size, SnapshotVersion versio
             if (index != 0)
             {
                 /// write data in batch to file
-                auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+                auto [save_size, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
                 checksum = new_checksum;
             }
 
@@ -328,7 +339,7 @@ void serializeMapV2(T & snap_map, UInt32 save_batch_size, SnapshotVersion versio
     }
 
     /// flush the last batch
-    auto [_, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum);
+    auto [_, new_checksum] = saveBatchAndUpdateCheckSumV2(out, batch, checksum, version);
     checksum = new_checksum;
     writeTailAndClose(out, checksum);
 }

--- a/src/Service/SnapshotCommon.h
+++ b/src/Service/SnapshotCommon.h
@@ -44,12 +44,13 @@ enum class SnapshotVersion : uint8_t
 String toString(SnapshotVersion version);
 
 
-static constexpr auto CURRENT_SNAPSHOT_VERSION = SnapshotVersion::V3;
+/// Maximum snapshot version we can read (write default is V2 for rolling-upgrade safety).
+static constexpr auto MAX_SNAPSHOT_VERSION = SnapshotVersion::V3;
 
 /// Batch data header in a snapshot object file.
 struct SnapshotBatchHeader
 {
-    /// The length of the batch data (uncompressed)
+    /// The length of the batch data on disk (compressed if V3+, raw otherwise)
     UInt32 data_length;
     /// The CRC32C of the batch data.
     /// If compression is enabled, this is the checksum of the compressed data.

--- a/src/Service/SnapshotCommon.h
+++ b/src/Service/SnapshotCommon.h
@@ -36,6 +36,7 @@ enum class SnapshotVersion : uint8_t
     V0 = 0,
     V1 = 1, /// Add ACL map
     V2 = 2, /// Replace protobuf
+    V3 = 3, /// zstd-compressed batch bodies
 
     UNKNOWN = 255,
 };
@@ -43,7 +44,7 @@ enum class SnapshotVersion : uint8_t
 String toString(SnapshotVersion version);
 
 
-static constexpr auto CURRENT_SNAPSHOT_VERSION = SnapshotVersion::V2;
+static constexpr auto CURRENT_SNAPSHOT_VERSION = SnapshotVersion::V3;
 
 /// Batch data header in a snapshot object file.
 struct SnapshotBatchHeader
@@ -107,9 +108,9 @@ ptr<KeeperNodeWithPath> parseKeeperNode(const String & buf, SnapshotVersion vers
 
 
 /// save batch data in snapshot object
-std::pair<size_t, UInt32> saveBatchV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch);
+std::pair<size_t, UInt32> saveBatchV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch, SnapshotVersion version);
 std::pair<size_t, UInt32>
-saveBatchAndUpdateCheckSumV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch, UInt32 checksum);
+saveBatchAndUpdateCheckSumV2(ptr<WriteBufferFromFile> & out, ptr<SnapshotBatchBody> & batch, UInt32 checksum, SnapshotVersion version);
 
 void serializeAclsV2(const NumToACLMap & acls, String path, UInt32 save_batch_size, SnapshotVersion version);
 

--- a/src/Service/tests/gtest_raft_snapshot.cpp
+++ b/src/Service/tests/gtest_raft_snapshot.cpp
@@ -676,6 +676,15 @@ TEST(RaftSnapshot, parseSnapshot)
 
     parseSnapshot(SnapshotVersion::V2, SnapshotVersion::V1);
     sleep(1);
+
+    parseSnapshot(SnapshotVersion::V3, SnapshotVersion::V3);
+    sleep(1);
+
+    parseSnapshot(SnapshotVersion::V2, SnapshotVersion::V3);
+    sleep(1);
+
+    parseSnapshot(SnapshotVersion::V3, SnapshotVersion::V2);
+    sleep(1);
 }
 
 TEST(RaftSnapshot, parseIncompleteSnapshot)

--- a/src/Service/tests/gtest_snapshot_zstd_bench.cpp
+++ b/src/Service/tests/gtest_snapshot_zstd_bench.cpp
@@ -1,0 +1,144 @@
+/**
+ * Benchmark: zstd snapshot compression (V2 raw vs V3 zstd) for RaftKeeper.
+ *
+ * Snapshots are the largest on-disk artifact and are transferred to lagging
+ * followers on catch-up, so the metrics that matter are on-disk size (network
+ * + disk) and create/load wall time (does compression slow snapshotting?).
+ *
+ * Run with:
+ *   ./build/src/rk_unit_tests --gtest_also_run_disabled_tests \
+ *       --gtest_filter='SnapshotZstdBench.*' 2>&1
+ *
+ * Output columns (one row per version, per store shape):
+ *   version | nodes | create_ms | load_ms | disk_MB | ratio
+ */
+#include <string>
+#include <vector>
+
+#include <Poco/File.h>
+#include <gtest/gtest.h>
+#include <libnuraft/nuraft.hxx>
+
+#include <Common/Stopwatch.h>
+#include <Service/NuRaftLogSnapshot.h>
+#include <Service/tests/raft_test_common.h>
+
+using namespace nuraft;
+using namespace RK;
+
+namespace
+{
+
+/// Build a payload resembling real ZK node data: mostly repetitive with a
+/// pseudo-random tail. Pure-random defeats compression; pure-repetition is
+/// unrealistically easy. Same shape as gtest_zstd_bench.cpp for comparability.
+String makeBenchData(int value_bytes, int salt)
+{
+    String s;
+    s.reserve(value_bytes);
+    int rep = value_bytes * 3 / 4;
+    for (int i = 0; i < rep; i++)
+        s += "abcdefghijklmnopqrstuvwxyz0123456789"[(i + salt) % 36];
+    for (int i = rep; i < value_bytes; i++)
+        s += static_cast<char>((i * 31 + 7 + salt) & 0x7f);
+    return s;
+}
+
+UInt64 dirSizeBytes(const String & dir)
+{
+    UInt64 total = 0;
+    std::vector<String> files;
+    Poco::File(dir).list(files);
+    for (const auto & f : files)
+        total += Poco::File(dir + "/" + f).getSize();
+    return total;
+}
+
+struct BenchResult
+{
+    SnapshotVersion version;
+    int nodes;
+    double create_ms;
+    double load_ms;
+    UInt64 disk_bytes;
+    double ratio; /// disk size of V2 baseline / this version's disk size
+};
+
+BenchResult runOne(SnapshotVersion version, int node_count, int value_bytes, int idx)
+{
+    String snap_dir = SNAP_DIR + "/zstd_bench_" + toString(version) + "_" + std::to_string(idx);
+    cleanDirectory(snap_dir);
+
+    KeeperSnapshotManager snap_mgr(snap_dir, 3, 10000);
+    ptr<cluster_config> config = cs_new<cluster_config>(1, 0);
+
+    RaftSettingsPtr raft_settings(RaftSettings::getDefault());
+    KeeperStore store(raft_settings->dead_session_check_period_ms);
+
+    for (int i = 0; i < node_count; i++)
+        setNode(store, std::to_string(i), makeBenchData(value_bytes, i));
+
+    snapshot meta(node_count, 1, config);
+
+    Stopwatch create_watch;
+    create_watch.start();
+    snap_mgr.createSnapshot(meta, store, store.getZxid(), store.getSessionIDCounter(), version);
+    create_watch.stop();
+
+    UInt64 disk = dirSizeBytes(snap_dir);
+
+    KeeperStore new_store(raft_settings->dead_session_check_period_ms);
+    Stopwatch load_watch;
+    load_watch.start();
+    snap_mgr.parseSnapshot(meta, new_store);
+    load_watch.stop();
+
+    /// sanity: loaded store must match
+    EXPECT_EQ(new_store.getNodesCount(), store.getNodesCount());
+
+    cleanDirectory(snap_dir);
+
+    BenchResult r;
+    r.version = version;
+    r.nodes = node_count;
+    r.create_ms = create_watch.elapsedMilliseconds();
+    r.load_ms = load_watch.elapsedMilliseconds();
+    r.disk_bytes = disk;
+    r.ratio = 1.0;
+    return r;
+}
+
+} // namespace
+
+
+/// DISABLED_ prefix: manual perf benchmark, skipped by default in every CI job.
+/// Run explicitly with --gtest_also_run_disabled_tests.
+TEST(SnapshotZstdBench, DISABLED_V2vsV3)
+{
+    struct Case { int nodes; int value_bytes; const char * label; };
+    std::vector<Case> cases = {
+        {100000, 128,  "100K x 128B"},
+        {100000, 307,  "100K x 0.3KB"},
+        {50000,  1024, "50K x 1KB"},
+    };
+
+    fprintf(stderr, "\n%-8s %10s %11s %10s %10s %8s\n",
+        "version", "nodes", "create_ms", "load_ms", "disk_MB", "ratio");
+    fprintf(stderr, "%s\n", std::string(60, '-').c_str());
+
+    int idx = 0;
+    for (auto & c : cases)
+    {
+        auto v2 = runOne(SnapshotVersion::V2, c.nodes, c.value_bytes, idx++);
+        auto v3 = runOne(SnapshotVersion::V3, c.nodes, c.value_bytes, idx++);
+        v3.ratio = v3.disk_bytes > 0 ? static_cast<double>(v2.disk_bytes) / v3.disk_bytes : 1.0;
+
+        fprintf(stderr, "── %s ──\n", c.label);
+        fprintf(stderr, "%-8s %10d %11.1f %10.1f %10.2f %8s\n",
+            "V2", v2.nodes, v2.create_ms, v2.load_ms, v2.disk_bytes / 1e6, "1.00");
+        fprintf(stderr, "%-8s %10d %11.1f %10.1f %10.2f %8.2f\n",
+            "V3", v3.nodes, v3.create_ms, v3.load_ms, v3.disk_bytes / 1e6, v3.ratio);
+    }
+
+    SUCCEED();
+}

--- a/tests/integration/test_snapshot_compression/configs/enable_keeper.xml
+++ b/tests/integration/test_snapshot_compression/configs/enable_keeper.xml
@@ -1,0 +1,12 @@
+<raftkeeper>
+    <keeper>
+        <my_id>1</my_id>
+        <host>node</host>
+        <create_snapshot_on_exit>0</create_snapshot_on_exit>
+        <raft_settings>
+            <snapshot_distance>20</snapshot_distance>
+            <async_snapshot>false</async_snapshot>
+            <snapshot_compression>zstd</snapshot_compression>
+        </raft_settings>
+    </keeper>
+</raftkeeper>

--- a/tests/integration/test_snapshot_compression/test.py
+++ b/tests/integration/test_snapshot_compression/test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Integration test for zstd-compressed snapshots (format V3).
+
+Verifies that:
+1. A node with snapshot_compression=zstd writes V3 snapshot objects on disk.
+2. State restored purely from a zstd snapshot (logs wiped) is intact.
+3. Data survives a hard restart (kill -9) that reloads from a zstd snapshot.
+"""
+import time
+
+import pytest
+
+from helpers.cluster_service import RaftKeeperCluster
+from helpers.utils import close_zk_clients
+
+cluster = RaftKeeperCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/enable_keeper.xml"],
+    stay_alive=True,
+)
+
+SNAP_DIR = "/var/lib/raftkeeper/data/raft_snapshot"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def snapshot_object_files(n):
+    """Data snapshot object file names (skip the 4 meta objects _1.._4)."""
+    out = n.exec_in_container(["bash", "-c", f"ls {SNAP_DIR} 2>/dev/null || true"])
+    return [f for f in out.split() if f.startswith("snapshot_")]
+
+
+def is_v3(n, fname):
+    """Header is 8-byte 'SnapHead' magic + 1 version byte; V3 == 0x03."""
+    byte = n.exec_in_container(
+        ["bash", "-c", f"dd if={SNAP_DIR}/{fname} bs=1 skip=8 count=1 2>/dev/null | od -An -tu1 | tr -d ' \\n'"]
+    ).strip()
+    return byte == "3"
+
+
+def force_snapshot(n):
+    n.send_4lw_cmd("csnp")
+
+
+def test_snapshot_written_as_v3(started_cluster):
+    """Snapshot objects on disk must carry the V3 version byte."""
+    zk = None
+    try:
+        zk = node.get_fake_zk(session_timeout=120)
+        for i in range(40):  # exceed snapshot_distance=20
+            zk.create(f"/test_v3_{i}", f"data{i}".encode())
+        close_zk_clients([zk])
+        zk = None
+
+        force_snapshot(node)
+
+        # csnp schedules the snapshot; poll for the object to land on disk
+        files = []
+        for _ in range(30):
+            files = snapshot_object_files(node)
+            if files and any(is_v3(node, f) for f in files):
+                break
+            time.sleep(1)
+        assert files, "no snapshot objects were created"
+        assert any(is_v3(node, f) for f in files), f"no V3 snapshot object among {files}"
+    finally:
+        close_zk_clients([zk])
+
+
+def test_restore_purely_from_zstd_snapshot(started_cluster):
+    """Wipe logs, keep only the zstd snapshot, and confirm state reloads."""
+    zk = zk2 = None
+    try:
+        zk = node.get_fake_zk(session_timeout=120)
+        zk.create("/test_v3_restore", b"root")
+        for i in range(40):
+            zk.create(f"/test_v3_restore/n{i}", f"v{i}".encode())
+        close_zk_clients([zk])
+        zk = None
+
+        force_snapshot(node)
+
+        node.stop_raftkeeper()
+        # remove logs so recovery must come from the zstd snapshot alone
+        node.exec_in_container(["bash", "-c", "rm -fr /var/lib/raftkeeper/data/raft_log/*"])
+        node.start_raftkeeper(start_wait=True)
+        node.wait_for_join_cluster()
+
+        zk2 = node.get_fake_zk()
+        assert zk2.get("/test_v3_restore")[0] == b"root"
+        for i in range(40):
+            assert zk2.get(f"/test_v3_restore/n{i}")[0] == f"v{i}".encode()
+    finally:
+        close_zk_clients([zk, zk2])
+
+
+def test_zstd_snapshot_survives_hard_restart(started_cluster):
+    """Data written under zstd snapshots must survive a kill -9 restart."""
+    zk = zk2 = None
+    try:
+        zk = node.get_fake_zk(session_timeout=120)
+        zk.create("/test_v3_hard", b"root")
+        for i in range(40):
+            zk.create(f"/test_v3_hard/n{i}", str(i).encode())
+        close_zk_clients([zk])
+        zk = None
+
+        force_snapshot(node)
+
+        node.restart_raftkeeper(kill=True)
+        node.wait_for_join_cluster()
+
+        zk2 = node.get_fake_zk()
+        assert zk2.get("/test_v3_hard")[0] == b"root"
+        for i in range(40):
+            assert zk2.get(f"/test_v3_hard/n{i}")[0] == str(i).encode()
+    finally:
+        close_zk_clients([zk, zk2])


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
Which issues of this PR fixes:
This PR try to close https://github.com/JDRaftKeeper/RaftKeeper/issues/395

### Change log:
<!-- (Please describe the changes you have made in details. -->

  Adds zstd compression for snapshots (snapshot format V3), the natural follow-up to zstd-compressed Raft log entries (#394). Snapshots are the
  largest on-disk artifact and are transferred to lagging followers on catch-up, yet were stored uncompressed.

  Behavior
  - New setting snapshot_compression (none | zstd), default none. Reuses the existing ZstdLogCodec (level 3).
  - Opt-in for rolling-upgrade safety: a V3-capable binary always reads V3, but keeps writing V2 until snapshot_compression=zstd is set. This
  keeps upgrades and downgrades safe, since a pre-V3 binary cannot read a V3 snapshot.

  Implementation
  - Compression slots into the two points the snapshot format already funnels through: saveBatchV2 on write and parseObject on read. No
  per-batch flag — the existing per-file version byte distinguishes raw vs zstd.
  - CRC is computed over the on-disk (compressed) bytes, matching the existing SnapshotBatchHeader.data_crc comment, so corruption is still
  caught before decompression.
  - Write-path default stays V2, so the converter and other default callers are unaffected; CURRENT_SNAPSHOT_VERSION=V3 only raises the max readable version.

```
Benchmark: V2 (raw) vs V3 (zstd level 3)

  version       nodes   create_ms    load_ms    disk_MB    ratio
  ------------------------------------------------------------
  ── 100K x 128B ──
  V2           100000       275.0       73.0      22.39     1.00
  V3           100000       237.0       59.0       2.00    11.17
  ── 100K x 0.3KB ──
  V2           100000       354.0       96.0      40.29     1.00
  V3           100000       265.0       69.0       2.14    18.85
  ── 50K x 1KB ──
  V2            50000       384.0       85.0      55.99     1.00
  V3            50000       194.0       62.0       1.14    48.93

  ┌──────────────┬───────────────┬─────────────┬────────────┐
  │ Store shape  │   Disk size   │ Create time │ Load time  │
  ├──────────────┼───────────────┼─────────────┼────────────┤
  │ 100K × 128B  │ 11.2× smaller │ 14% faster  │ 19% faster │
  ├──────────────┼───────────────┼─────────────┼────────────┤
  │ 100K × 0.3KB │ 18.9× smaller │ 25% faster  │ 28% faster │
  ├──────────────┼───────────────┼─────────────┼────────────┤
  │ 50K × 1KB    │ 48.9× smaller │ 49% faster  │ 27% faster │
  └──────────────┴───────────────┴─────────────┴────────────┘

  V3 wins on every axis — unlike the log path (where per-entry compression costs write throughput), snapshot bodies are batched into large zstd
  frames, so writing/reading far fewer bytes outweighs the zstd CPU cost. Ratios climb with value size as the compressible payload comes to
  dominate fixed per-node overhead.
```