### PR TITLE
fix: MultiRead zxid and watch registration

### DIFF
--- a/src/Service/KeeperStore.cpp
+++ b/src/Service/KeeperStore.cpp
@@ -119,7 +119,8 @@ static bool shouldIncreaseZxid(const Coordination::ZooKeeperRequestPtr & zk_requ
         || dynamic_cast<Coordination::ZooKeeperAuthRequest *>(zk_request.get())
         || dynamic_cast<Coordination::ZooKeeperHeartbeatRequest *>(zk_request.get())
         || dynamic_cast<Coordination::ZooKeeperListRequest *>(zk_request.get())
-        || dynamic_cast<Coordination::ZooKeeperSimpleListRequest *>(zk_request.get()));
+        || dynamic_cast<Coordination::ZooKeeperSimpleListRequest *>(zk_request.get())
+        || zk_request->getOpNum() == Coordination::OpNum::MultiRead);
 }
 
 KeeperNodePtr KeeperNode::clone() const
@@ -1348,6 +1349,62 @@ void KeeperStore::processRequest(
         set_response(responses_queue, watch_responses, ignore_response);
 
         /// no response for SetWatches request
+        set_response(responses_queue, ResponseForSession{session_id, response}, ignore_response);
+    }
+    else if (zk_request->getOpNum() == Coordination::OpNum::MultiRead)
+    {
+        auto & multi_request = dynamic_cast<Coordination::ZooKeeperMultiRequest &>(*zk_request);
+        auto response = zk_request->makeResponse();
+        auto & multi_response = dynamic_cast<Coordination::ZooKeeperMultiResponse &>(*response);
+
+        for (size_t i = 0; i < multi_request.requests.size(); ++i)
+        {
+            auto sub_zk_request = std::dynamic_pointer_cast<Coordination::ZooKeeperRequest>(multi_request.requests[i]);
+            auto sub_opnum = sub_zk_request->getOpNum();
+
+            /// MultiRead only allows read operations. Writes routed here would bypass Raft consensus.
+            if (sub_opnum != Coordination::OpNum::Get
+                && sub_opnum != Coordination::OpNum::Exists
+                && sub_opnum != Coordination::OpNum::List
+                && sub_opnum != Coordination::OpNum::SimpleList
+                && sub_opnum != Coordination::OpNum::FilteredList
+                && sub_opnum != Coordination::OpNum::GetACL)
+            {
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Illegal command {} as part of MultiRead request",
+                    Coordination::toString(sub_opnum));
+            }
+
+            auto sub_store_request = StoreRequestFactory::instance().get(sub_zk_request);
+            Coordination::ZooKeeperResponsePtr sub_response;
+
+            if (check_acl && !sub_store_request->checkAuth(*this, session_id))
+            {
+                sub_response = sub_zk_request->makeResponse();
+                sub_response->error = Coordination::Error::ZNOAUTH;
+            }
+            else
+            {
+                sub_response = sub_store_request->process(*this, zxid, session_id, request_for_session.process_time).first;
+            }
+
+            sub_response->xid = sub_zk_request->xid;
+            sub_response->zxid = zxid.load();
+
+            if (sub_zk_request->has_watch && (sub_response->error == Coordination::Error::ZOK
+                || (sub_response->error == Coordination::Error::ZNONODE && sub_zk_request->getOpNum() == Coordination::OpNum::Exists)))
+            {
+                watch_manager.registerWatches(sub_zk_request->getPath(), session_id, sub_zk_request->getOpNum());
+            }
+
+            multi_response.responses[i] = sub_response;
+        }
+
+        response->request_created_time_ms = request_for_session.create_time;
+        response->xid = zk_request->xid;
+        response->zxid = zxid.load(); /// ponytail: MultiRead is always processed locally, never gets new_last_zxid
+
         set_response(responses_queue, ResponseForSession{session_id, response}, ignore_response);
     }
     else

--- a/src/Service/tests/gtest_raft_state_machine.cpp
+++ b/src/Service/tests/gtest_raft_state_machine.cpp
@@ -299,3 +299,180 @@ TEST(RaftStateMachine, initStateMachine)
     cleanDirectory(snap_dir);
     cleanDirectory(log_dir);
 }
+
+TEST(RaftStateMachine, MultiReadDoesNotIncreaseZxid)
+{
+    String snap_dir(SNAP_DIR + "/multiread_zxid");
+    String log_dir(LOG_DIR + "/multiread_zxid");
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+
+    KeeperResponsesQueue queue;
+    RaftSettingsPtr setting_ptr = RaftSettings::getDefault();
+
+    std::mutex new_session_id_callback_mutex;
+    std::unordered_map<int64_t, ptr<std::condition_variable>> new_session_id_callback;
+
+    NuRaftStateMachine machine(queue, setting_ptr, snap_dir, log_dir, 10, 3, new_session_id_callback_mutex, new_session_id_callback);
+
+    /// Set up: create a session and a test node
+    int64_t session_id = machine.getStore().getSessionID(30000);
+    setNode(machine.getStore(), "test_node", "test_data", /*is_ephemeral=*/false, session_id);
+
+    /// Record zxid before MultiRead
+    int64_t zxid_before = machine.getStore().getZxid();
+
+    /// Build MultiRead request
+    auto multi_read = cs_new<ZooKeeperMultiRequest>();
+    multi_read->operation_type = ZooKeeperMultiRequest::OperationType::Read;
+    multi_read->xid = 100;
+
+    for (int i = 0; i < 5; ++i)
+    {
+        auto get_req = cs_new<ZooKeeperGetRequest>();
+        get_req->path = "/test_node";
+        get_req->xid = 100;
+        multi_read->requests.push_back(get_req);
+    }
+
+    /// Process
+    KeeperStore::KeeperResponsesQueue response_queue;
+    int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    machine.getStore().processRequest(
+        response_queue, {multi_read, session_id, time}, {}, /*check_acl=*/true, /*ignore_response=*/false);
+
+    /// Verify zxid didn't change
+    ASSERT_EQ(machine.getStore().getZxid(), zxid_before);
+
+    /// Verify response
+    ResponseForSession response_for_session;
+    ASSERT_TRUE(response_queue.tryPop(response_for_session));
+    ASSERT_EQ(response_for_session.response->getOpNum(), OpNum::MultiRead);
+    auto & multi_response = dynamic_cast<ZooKeeperMultiResponse &>(*response_for_session.response);
+    ASSERT_EQ(multi_response.responses.size(), 5u);
+    for (size_t i = 0; i < 5; ++i)
+        ASSERT_EQ(multi_response.responses[i]->error, Error::ZOK);
+
+    machine.shutdown();
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+}
+
+TEST(RaftStateMachine, MultiReadRegistersSubrequestWatches)
+{
+    String snap_dir(SNAP_DIR + "/multiread_watch");
+    String log_dir(LOG_DIR + "/multiread_watch");
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+
+    KeeperResponsesQueue queue;
+    RaftSettingsPtr setting_ptr = RaftSettings::getDefault();
+
+    std::mutex new_session_id_callback_mutex;
+    std::unordered_map<int64_t, ptr<std::condition_variable>> new_session_id_callback;
+
+    NuRaftStateMachine machine(queue, setting_ptr, snap_dir, log_dir, 10, 3, new_session_id_callback_mutex, new_session_id_callback);
+
+    int64_t session_id = machine.getStore().getSessionID(30000);
+    setNode(machine.getStore(), "test_node_a", "data_a", /*is_ephemeral=*/false, session_id);
+    setNode(machine.getStore(), "test_node_b", "data_b", /*is_ephemeral=*/false, session_id);
+
+    /// Count watches before
+    uint64_t watches_before = machine.getStore().getTotalWatchesCount();
+
+    /// Build MultiRead with watched subrequests on different paths
+    auto multi_read = cs_new<ZooKeeperMultiRequest>();
+    multi_read->operation_type = ZooKeeperMultiRequest::OperationType::Read;
+    multi_read->xid = 200;
+
+    /// Get with watch on path A
+    {
+        auto req = cs_new<ZooKeeperGetRequest>();
+        req->path = "/test_node_a";
+        req->has_watch = true;
+        req->xid = 200;
+        multi_read->requests.push_back(req);
+    }
+    /// Exists with watch on path B
+    {
+        auto req = cs_new<ZooKeeperExistsRequest>();
+        req->path = "/test_node_b";
+        req->has_watch = true;
+        req->xid = 200;
+        multi_read->requests.push_back(req);
+    }
+
+    KeeperStore::KeeperResponsesQueue response_queue;
+    int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    machine.getStore().processRequest(
+        response_queue, {multi_read, session_id, time}, {}, /*check_acl=*/true, /*ignore_response=*/false);
+
+    /// Both subrequests registered watches
+    ASSERT_EQ(machine.getStore().getTotalWatchesCount(), watches_before + 2);
+
+    /// Verify response
+    ResponseForSession response_for_session;
+    ASSERT_TRUE(response_queue.tryPop(response_for_session));
+    auto & multi_response = dynamic_cast<ZooKeeperMultiResponse &>(*response_for_session.response);
+    ASSERT_EQ(multi_response.responses.size(), 2u);
+    ASSERT_EQ(multi_response.responses[0]->error, Error::ZOK);
+    ASSERT_EQ(multi_response.responses[1]->error, Error::ZOK);
+
+    machine.shutdown();
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+}
+
+TEST(RaftStateMachine, MultiReadHandlesIndividualErrors)
+{
+    String snap_dir(SNAP_DIR + "/multiread_error");
+    String log_dir(LOG_DIR + "/multiread_error");
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+
+    KeeperResponsesQueue queue;
+    RaftSettingsPtr setting_ptr = RaftSettings::getDefault();
+
+    std::mutex new_session_id_callback_mutex;
+    std::unordered_map<int64_t, ptr<std::condition_variable>> new_session_id_callback;
+
+    NuRaftStateMachine machine(queue, setting_ptr, snap_dir, log_dir, 10, 3, new_session_id_callback_mutex, new_session_id_callback);
+
+    int64_t session_id = machine.getStore().getSessionID(30000);
+    setNode(machine.getStore(), "test_node", "test_data", /*is_ephemeral=*/false, session_id);
+
+    /// Build MultiRead: one valid path, one nonexistent path
+    auto multi_read = cs_new<ZooKeeperMultiRequest>();
+    multi_read->operation_type = ZooKeeperMultiRequest::OperationType::Read;
+    multi_read->xid = 300;
+
+    {
+        auto req = cs_new<ZooKeeperGetRequest>();
+        req->path = "/test_node";
+        req->xid = 300;
+        multi_read->requests.push_back(req);
+    }
+    {
+        auto req = cs_new<ZooKeeperGetRequest>();
+        req->path = "/nonexistent_path";
+        req->xid = 300;
+        multi_read->requests.push_back(req);
+    }
+
+    KeeperStore::KeeperResponsesQueue response_queue;
+    int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    machine.getStore().processRequest(
+        response_queue, {multi_read, session_id, time}, {}, /*check_acl=*/true, /*ignore_response=*/false);
+
+    /// Each subrequest has its own error — first succeeds, second fails with ZNONODE
+    ResponseForSession response_for_session;
+    ASSERT_TRUE(response_queue.tryPop(response_for_session));
+    auto & multi_response = dynamic_cast<ZooKeeperMultiResponse &>(*response_for_session.response);
+    ASSERT_EQ(multi_response.responses.size(), 2u);
+    ASSERT_EQ(multi_response.responses[0]->error, Error::ZOK);
+    ASSERT_EQ(multi_response.responses[1]->error, Error::ZNONODE);
+
+    machine.shutdown();
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+}

--- a/src/Service/tests/gtest_raft_state_machine.cpp
+++ b/src/Service/tests/gtest_raft_state_machine.cpp
@@ -476,3 +476,189 @@ TEST(RaftStateMachine, MultiReadHandlesIndividualErrors)
     cleanDirectory(snap_dir);
     cleanDirectory(log_dir);
 }
+
+TEST(RaftStateMachine, MultiReadRejectsWriteOps)
+{
+    String snap_dir(SNAP_DIR + "/multiread_reject");
+    String log_dir(LOG_DIR + "/multiread_reject");
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+
+    KeeperResponsesQueue queue;
+    RaftSettingsPtr setting_ptr = RaftSettings::getDefault();
+
+    std::mutex new_session_id_callback_mutex;
+    std::unordered_map<int64_t, ptr<std::condition_variable>> new_session_id_callback;
+
+    NuRaftStateMachine machine(queue, setting_ptr, snap_dir, log_dir, 10, 3, new_session_id_callback_mutex, new_session_id_callback);
+    int64_t session_id = machine.getStore().getSessionID(30000);
+    setNode(machine.getStore(), "test_node", "test_data", false, session_id);
+
+    /// Build MultiRead with a Create subrequest — should be rejected
+    auto multi_read = cs_new<ZooKeeperMultiRequest>();
+    multi_read->operation_type = ZooKeeperMultiRequest::OperationType::Read;
+    multi_read->xid = 400;
+
+    {
+        auto req = cs_new<ZooKeeperGetRequest>();
+        req->path = "/test_node";
+        req->xid = 400;
+        multi_read->requests.push_back(req);
+    }
+    {
+        Coordination::ACLs acls;
+        Coordination::ACL acl;
+        acl.permissions = Coordination::ACL::All;
+        acl.scheme = "world";
+        acl.id = "anyone";
+        acls.emplace_back(std::move(acl));
+        auto req = cs_new<ZooKeeperCreateRequest>();
+        req->path = "/test_node/should_fail";
+        req->data = "bad";
+        req->acls = acls;
+        req->xid = 400;
+        multi_read->requests.push_back(req);
+    }
+
+    KeeperStore::KeeperResponsesQueue response_queue;
+    int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    EXPECT_THROW(
+        {
+            machine.getStore().processRequest(
+                response_queue, {multi_read, session_id, time}, {}, /*check_acl=*/true, /*ignore_response=*/false);
+        },
+        RK::Exception);
+
+    machine.shutdown();
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+}
+
+TEST(RaftStateMachine, MultiReadExistsWatchOnNonExistentNode)
+{
+    String snap_dir(SNAP_DIR + "/multiread_watch_nonexistent");
+    String log_dir(LOG_DIR + "/multiread_watch_nonexistent");
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+
+    KeeperResponsesQueue queue;
+    RaftSettingsPtr setting_ptr = RaftSettings::getDefault();
+
+    std::mutex new_session_id_callback_mutex;
+    std::unordered_map<int64_t, ptr<std::condition_variable>> new_session_id_callback;
+
+    NuRaftStateMachine machine(queue, setting_ptr, snap_dir, log_dir, 10, 3, new_session_id_callback_mutex, new_session_id_callback);
+    int64_t session_id = machine.getStore().getSessionID(30000);
+    uint64_t watches_before = machine.getStore().getTotalWatchesCount();
+
+    /// Exists with watch on a path that does NOT exist — watch should still be registered
+    auto multi_read = cs_new<ZooKeeperMultiRequest>();
+    multi_read->operation_type = ZooKeeperMultiRequest::OperationType::Read;
+    multi_read->xid = 500;
+
+    {
+        auto req = cs_new<ZooKeeperExistsRequest>();
+        req->path = "/nonexistent_path";
+        req->has_watch = true;
+        req->xid = 500;
+        multi_read->requests.push_back(req);
+    }
+
+    KeeperStore::KeeperResponsesQueue response_queue;
+    int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    machine.getStore().processRequest(
+        response_queue, {multi_read, session_id, time}, {}, /*check_acl=*/true, /*ignore_response=*/false);
+
+    /// Watch must be registered even on ZNONODE for Exists
+    ASSERT_EQ(machine.getStore().getTotalWatchesCount(), watches_before + 1);
+
+    /// Response should carry ZNONODE error
+    ResponseForSession response_for_session;
+    ASSERT_TRUE(response_queue.tryPop(response_for_session));
+    auto & multi_response = dynamic_cast<ZooKeeperMultiResponse &>(*response_for_session.response);
+    ASSERT_EQ(multi_response.responses.size(), 1u);
+    ASSERT_EQ(multi_response.responses[0]->error, Error::ZNONODE);
+
+    machine.shutdown();
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+}
+
+TEST(RaftStateMachine, MultiReadAuthCheckPerSubrequest)
+{
+    String snap_dir(SNAP_DIR + "/multiread_acl");
+    String log_dir(LOG_DIR + "/multiread_acl");
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+
+    KeeperResponsesQueue queue;
+    RaftSettingsPtr setting_ptr = RaftSettings::getDefault();
+
+    std::mutex new_session_id_callback_mutex;
+    std::unordered_map<int64_t, ptr<std::condition_variable>> new_session_id_callback;
+
+    NuRaftStateMachine machine(queue, setting_ptr, snap_dir, log_dir, 10, 3, new_session_id_callback_mutex, new_session_id_callback);
+    int64_t session_id = machine.getStore().getSessionID(30000);
+
+    /// Create node A with world-readable ACL (accessible)
+    setNode(machine.getStore(), "public_node", "public_data", false, session_id);
+
+    /// Create node B with auth-only ACL (not readable by this session)
+    {
+        Coordination::ACLs restricted_acls;
+        Coordination::ACL acl;
+        acl.permissions = Coordination::ACL::All;
+        acl.scheme = "digest";
+        acl.id = "user:password";
+        restricted_acls.emplace_back(std::move(acl));
+
+        auto create_req = cs_new<ZooKeeperCreateRequest>();
+        create_req->path = "/restricted_node";
+        create_req->data = "secret";
+        create_req->is_ephemeral = false;
+        create_req->is_sequential = false;
+        create_req->acls = restricted_acls;
+        create_req->xid = 600;
+
+        KeeperStore::KeeperResponsesQueue rsp_queue;
+        int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+        machine.getStore().processRequest(
+            rsp_queue, {create_req, session_id, time}, {}, /*check_acl=*/true, /*ignore_response=*/true);
+    }
+
+    /// MultiRead with Get on both nodes
+    auto multi_read = cs_new<ZooKeeperMultiRequest>();
+    multi_read->operation_type = ZooKeeperMultiRequest::OperationType::Read;
+    multi_read->xid = 601;
+
+    {
+        auto req = cs_new<ZooKeeperGetRequest>();
+        req->path = "/public_node";
+        req->xid = 601;
+        multi_read->requests.push_back(req);
+    }
+    {
+        auto req = cs_new<ZooKeeperGetRequest>();
+        req->path = "/restricted_node";
+        req->xid = 601;
+        multi_read->requests.push_back(req);
+    }
+
+    KeeperStore::KeeperResponsesQueue response_queue;
+    int64_t time = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
+    machine.getStore().processRequest(
+        response_queue, {multi_read, session_id, time}, {}, /*check_acl=*/true, /*ignore_response=*/false);
+
+    ResponseForSession response_for_session;
+    ASSERT_TRUE(response_queue.tryPop(response_for_session));
+    auto & multi_response = dynamic_cast<ZooKeeperMultiResponse &>(*response_for_session.response);
+    ASSERT_EQ(multi_response.responses.size(), 2u);
+    /// public_node: readable by world:anyone
+    ASSERT_EQ(multi_response.responses[0]->error, Error::ZOK);
+    /// restricted_node: auth-only ACL, session has no auth → ZNOAUTH
+    ASSERT_EQ(multi_response.responses[1]->error, Error::ZNOAUTH);
+
+    machine.shutdown();
+    cleanDirectory(snap_dir);
+    cleanDirectory(log_dir);
+}

--- a/tests/integration/helpers/utils.py
+++ b/tests/integration/helpers/utils.py
@@ -1,4 +1,4 @@
-from kazoo.client import KazooClient, Create, GetData, GetChildren, OPEN_ACL_UNSAFE, \
+from kazoo.client import KazooClient, Create, GetData, GetChildren, Exists, OPEN_ACL_UNSAFE, \
     GetChildren2, Exists, TransactionRequest, Create2
 from kazoo.protocol.paths import _prefix_root
 from kazoo.protocol.serialization import MultiHeader, Transaction, multiheader_struct, int_struct, read_string, \
@@ -133,6 +133,12 @@ class MultiReadRequest(object):
         :returns: None
         """
         self._add(GetChildren(path, watcher), None)
+
+    def exists(self, path, watcher):
+        """Add an exists ZNode ops to the operations.
+        :returns: None
+        """
+        self._add(Exists(path, watcher), None)
 
     def get_children3(self, path, list_type, watcher):
         """Add a filteredList ops to the operations.

--- a/tests/integration/test_back_to_back/test.py
+++ b/tests/integration/test_back_to_back/test.py
@@ -909,7 +909,7 @@ def test_multi_read_zxid_stability(started_cluster):
         assert len(results) == 3
         assert results[0][0] == b'data_a'
         assert results[1][0] == b'data_b'
-        assert sorted(results[2][0]) == ['a', 'b']
+        assert sorted(results[2]) == ['a', 'b']
 
         zxid_after = get_zxid_from_srvr(node1)
         assert zxid_after == zxid_before, \

--- a/tests/integration/test_back_to_back/test.py
+++ b/tests/integration/test_back_to_back/test.py
@@ -4,6 +4,7 @@ import random
 import string
 import os
 import time
+import csv
 from multiprocessing.dummy import Pool
 from kazoo.client import KazooClient, KazooState
 from helpers.cluster_service import RaftKeeperCluster
@@ -873,6 +874,77 @@ def test_unregister_watch(started_cluster):
             print(f"Data {index}: {data}")
             
         for data0, data1 in zip(datas[0], datas[1]):
-            assert len(data0[0].splitlines()) == len(data1[1].splitlines())  
+            assert len(data0[0].splitlines()) == len(data1[1].splitlines())
     finally:
         close_zk_clients([genuine_zk, fake_zk])
+
+
+def get_zxid_from_mntr(node):
+    """Extract Zxid from node's mntr output."""
+    data = node.send_4lw_cmd(cmd='mntr')
+    reader = csv.reader(data.split('\n'), delimiter='\t')
+    for row in reader:
+        if len(row) == 2 and row[0] == 'Zxid':
+            return int(row[1])
+    raise Exception("Zxid not found in mntr output")
+
+
+def test_multi_read_zxid_stability(started_cluster):
+    fake_zk = None
+    try:
+        fake_zk = get_fake_zk(True)
+        fake_zk.start()
+
+        fake_zk.create('/test_multiread_zxid')
+        fake_zk.create('/test_multiread_zxid/a', b'data_a')
+        fake_zk.create('/test_multiread_zxid/b', b'data_b')
+
+        zxid_before = get_zxid_from_mntr(node1)
+
+        t = fake_zk.multi_read()
+        t.get('/test_multiread_zxid/a', None)
+        t.get('/test_multiread_zxid/b', None)
+        t.get_children('/test_multiread_zxid', None)
+        results = t.commit()
+        assert len(results) == 3
+        assert results[0][0] == b'data_a'
+        assert results[1][0] == b'data_b'
+        assert sorted(results[2][0]) == ['a', 'b']
+
+        zxid_after = get_zxid_from_mntr(node1)
+        assert zxid_after == zxid_before, \
+            f"MultiRead incorrectly advanced zxid from {zxid_before} to {zxid_after}"
+
+    finally:
+        close_zk_clients([fake_zk])
+
+
+def test_multi_read_subrequest_watch(started_cluster):
+    """Verify MultiRead subrequests with watch=true register watches server-side."""
+    fake_zk = None
+    try:
+        fake_zk = get_fake_zk(True)
+        fake_zk.start()
+
+        fake_zk.create('/test_multiread_watch')
+        fake_zk.create('/test_multiread_watch/node_a', b'data_a')
+        fake_zk.create('/test_multiread_watch/node_b', b'data_b')
+
+        t = fake_zk.multi_read()
+        t.get('/test_multiread_watch/node_a', lambda e: None)
+        t.exists('/test_multiread_watch/node_b', lambda e: None)
+        results = t.commit()
+        assert len(results) == 2
+        assert results[0][0] == b'data_a'
+        assert results[1] is not None
+
+        # Verify watches were registered server-side via wchc (watch by session) 4LW
+        # Format: <session_id_hex>\n\t<path>\n\t<path>\n...
+        wchc_output = node1.send_4lw_cmd(cmd='wchc')
+        assert '/test_multiread_watch/node_a' in wchc_output, \
+            "Get watch from MultiRead subrequest not registered on server"
+        assert '/test_multiread_watch/node_b' in wchc_output, \
+            "Exists watch from MultiRead subrequest not registered on server"
+
+    finally:
+        close_zk_clients([fake_zk])

--- a/tests/integration/test_back_to_back/test.py
+++ b/tests/integration/test_back_to_back/test.py
@@ -879,14 +879,14 @@ def test_unregister_watch(started_cluster):
         close_zk_clients([genuine_zk, fake_zk])
 
 
-def get_zxid_from_mntr(node):
-    """Extract Zxid from node's mntr output."""
-    data = node.send_4lw_cmd(cmd='mntr')
-    reader = csv.reader(data.split('\n'), delimiter='\t')
+def get_zxid_from_srvr(node):
+    """Extract Zxid from node's srvr output (format: 'Key: value')."""
+    data = node.send_4lw_cmd(cmd='srvr')
+    reader = csv.reader(data.split('\n'), delimiter=':')
     for row in reader:
-        if len(row) == 2 and row[0] == 'Zxid':
-            return int(row[1])
-    raise Exception("Zxid not found in mntr output")
+        if len(row) >= 2 and row[0].strip() == 'Zxid':
+            return int(row[1].strip())
+    raise Exception("Zxid not found in srvr output")
 
 
 def test_multi_read_zxid_stability(started_cluster):
@@ -899,7 +899,7 @@ def test_multi_read_zxid_stability(started_cluster):
         fake_zk.create('/test_multiread_zxid/a', b'data_a')
         fake_zk.create('/test_multiread_zxid/b', b'data_b')
 
-        zxid_before = get_zxid_from_mntr(node1)
+        zxid_before = get_zxid_from_srvr(node1)
 
         t = fake_zk.multi_read()
         t.get('/test_multiread_zxid/a', None)
@@ -911,7 +911,7 @@ def test_multi_read_zxid_stability(started_cluster):
         assert results[1][0] == b'data_b'
         assert sorted(results[2][0]) == ['a', 'b']
 
-        zxid_after = get_zxid_from_mntr(node1)
+        zxid_after = get_zxid_from_srvr(node1)
         assert zxid_after == zxid_before, \
             f"MultiRead incorrectly advanced zxid from {zxid_before} to {zxid_after}"
 


### PR DESCRIPTION
### Which issues of this PR fixes:
<!-- Usage: `Fixes #<issue number>` -->
This PR try to fix #

### Change log:
<!-- (Please describe the changes you have made in details. -->
Two fixes for MultiRead (OpNum 22) processing:

1. zxid: MultiRead no longer consumes a zxid. Added OpNum::MultiRead to shouldIncreaseZxid() exclusion list. MultiRead is a read-only operation — only write requests should advance the global transaction ID.

2. Unbundle & watches: MultiRead subrequests are now processed individually instead of through StoreRequestMultiTxn. Each subrequest gets:
   - Independent ACL check
   - Per-subrequest watch registration (was silently dropped before — only the outer MultiRead wrapper's has_watch was checked, which is always false)
   - Individual error codes preserved per subrequest

   Added an allowlist guard rejecting write ops (Create/Set/Remove) inside
   MultiRead — without this they would bypass Raft consensus.

Tests: 3 unit (zxid stability, watch registration, per-subrequest errors)
       + 2 integration (zxid via mntr, watches via wchc 4LW)

